### PR TITLE
Updates Dataset Downloads to 2.1, Switches Download Hosting to Azure

### DIFF
--- a/data.php
+++ b/data.php
@@ -26,14 +26,14 @@
         <div method="post" class="small-12 medium-11 large-9 cell grid-x data-form">
             <h2>Export the Full Dataset</h2>
             <ul class="no-bullet">
-                <li><a href="/downloads/LondonStageSQL.zip">SQL:</a> <b>S</b>tructured <b>Q</b>uery <b>L</b>anguage</li>
-                <li><a href="/downloads/LondonStageJSON.zip">JSON:</a> <b>J</b>ava<b>S</b>cript <b>O</b>bject <b>N</b>otation:
+                <li><a href="https://londonstage.blob.core.windows.net/lsdb-files/downloads/London.sql.zip">SQL:</a> <b>S</b>tructured <b>Q</b>uery <b>L</b>anguage</li>
+                <li><a href="https://londonstage.blob.core.windows.net/lsdb-files/downloads/LondonStageFull.json.zip">JSON:</a> <b>J</b>ava<b>S</b>cript <b>O</b>bject <b>N</b>otation:
                     a data-interchange format that stores data objects as text
                 </li>
-                <li><a href="/downloads/LondonStageXML.zip">XML:</a> e<b>X</b>tensible <b>M</b>arkup <b>L</b>anguage, a
+                <li><a href="https://londonstage.blob.core.windows.net/lsdb-files/downloads/LondonStageFull.xml.zip">XML:</a> e<b>X</b>tensible <b>M</b>arkup <b>L</b>anguage, a
                     markup language similar to HTML. Data is represented as text wrapped within tags
                 </li>
-                <li><a href="/downloads/LondonStageCSV.zip">CSV:</a> <b>C</b>omma <b>S</b>eparated <b>V</b>alues, a
+                <li><a href="https://londonstage.blob.core.windows.net/lsdb-files/downloads/LondonStageFull.csv.zip">CSV:</a> <b>C</b>omma <b>S</b>eparated <b>V</b>alues, a
                     tabular data file format in which values are delimited using the comma character</a></li>
             </ul>
             <p>Data for individual events can be exported from the relevant Event page.</p>


### PR DESCRIPTION
Updates and migrates the zipped dataset downloads in the `downloads` folder made available [on the Data Downloads page](https://londonstagedb.uoregon.edu/data.php) to dedicated cloud storage on Azure.*

This will be followed by the removal of these zipped files from the repository.

Tested in the LSDB Docker Environment and on the staging environment.

*The downloads available on the production server were manually updated on the day of the rollout.