### PR TITLE
Bug fix

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -655,6 +655,12 @@
     $string = str_replace('”', '"', $string);
     $string = str_replace('“', '"', $string);
 
+    if (gettype($string) == "string") {
+      $string = strip_tags($string);
+    } elseif (gettype($string) == "array") {
+      $string = array_map('strip_tags', $string);
+    }
+
     return preg_replace('/[^A-Za-z0-9 ;"]/', '', $string);
   }
 
@@ -1769,8 +1775,9 @@
 
     preg_match_all('~[^|]+~', $words, $m); // Array of | delimited phrases
     preg_match_all('~[^| ]+~', $words, $n); // Array of each word in each phrase
-    $cleaned = array_map('cleanStr', $n);
-    $allWords = array_unique(array_merge($m[0], $n[0], $cleaned[0])); // Combine unique
+    $cleanedN = array_map('cleanStr', $n[0]);
+    $cleanedM = array_map('cleanStr', $m[0]);
+    $allWords = array_unique(array_merge($cleanedM, $cleanedN)); // Combine unique
     if(!$allWords || count($allWords) === 0) {
         return $text;
     }
@@ -1848,8 +1855,8 @@
     preg_match_all('~[^| ]+~', $actorSearch, $an); // Actor search terms ' ' delimited array
     preg_match_all('~[^|]+~', $roleSearch, $rm); // Role search terms | delimited array
     preg_match_all('~[^| ]+~', $roleSearch, $rn); // Role search terms ' ' delimited array
-    $allActors = array_unique(array_merge($am[0], $an[0])); // Combine unique
-    $allRoles = array_unique(array_merge($rm[0], $rn[0])); // Combine unique
+    $allActors = array_unique(array_merge(cleanStr($am[0]), cleanStr($an[0]))); // Combine unique
+    $allRoles = array_unique(array_merge(cleanStr($rm[0]), cleanStr($rn[0]))); // Combine unique
     if((!is_array($allActors) || count($allActors) === 0) && (!is_array($allRoles) || count($allRoles) === 0)) {
         return false;
     }

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -14,7 +14,10 @@
 
   // Get and sanitize 'limit' and 'p' for pagination
   $g_lim = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_NUMBER_INT);
+  // Prevent SQL injection
+  if(gettype($g_lim) == 'string') $g_lim = '';
   $g_p = filter_input(INPUT_GET, 'p', FILTER_SANITIZE_NUMBER_INT);
+  if(gettype($g_p) == 'string') $g_p = '';
   $limit      = ( $g_lim !== '' && $g_lim > 0 ) ? $g_lim : 25;
   $page       = ( $g_p !== '' && $g_p > 0 ) ? $g_p : 1;
   $links      = 3;

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -15,9 +15,10 @@
   // Get and sanitize 'limit' and 'p' for pagination
   $g_lim = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_NUMBER_INT);
   // Prevent SQL injection
-  if(gettype($g_lim) == 'string') $g_lim = '';
+  if(!is_numeric($g_lim)) $g_lim = '';
   $g_p = filter_input(INPUT_GET, 'p', FILTER_SANITIZE_NUMBER_INT);
-  if(gettype($g_p) == 'string') $g_p = '';
+  // Prevent SQL injection
+  if(!is_numeric($g_p)) $g_p = '';
   $limit      = ( $g_lim !== '' && $g_lim > 0 ) ? $g_lim : 25;
   $page       = ( $g_p !== '' && $g_p > 0 ) ? $g_p : 1;
   $links      = 3;


### PR DESCRIPTION
We found two bugs in the current site:

1. Some keywords contained HTML tags inside. After looking through the logs, we found they came from some pages like: https://londonstagedb.uoregon.edu/event.php?id=37896. The link in the page was generated from the PDF SCR which contained HTML tags. This PR will strip off those HTML tags.
2. We also noticed a lot of fetal errors every time the server hit Socket Timeout/no responding. After diving into the logs, we found some hackers tried to SQL Inject the query. Because we're using Sphinx, it will not hurt or expose anything. But it indeed uses VM resources to deal with the exceptions. This PR will detect if the limit value is an integer.  The hacking injection is: /sphinx-results.php?keyword=Lord Hinchingbroke&limit=25') as tempxtestxtable where 1=1-- -&p=82

@wintere, please test it in the staging site asap. I would like to patch it in the live site asap.