### PR TITLE
Two more bugs found

### DIFF
--- a/includes/SphinxPaginator.class.php
+++ b/includes/SphinxPaginator.class.php
@@ -12,16 +12,20 @@ class SphinxPaginator {
     $this->_conn  = $conn;
     $this->_query = $query;
 
-    $this->_conn->query( $this->_query ); // Execute the query.
-    // To find the total number of results with sphinx, a follow up query
-    // should be done to look up the previous query's meta info.
-    $rs = $this->_conn->query( 'SHOW META;' );
+    if ($query == "") {
+      $this->_total = 0;
+    } else {
+      $this->_conn->query( $this->_query ); // Execute the query.
+      // To find the total number of results with sphinx, a follow up query
+      // should be done to look up the previous query's meta info.
+      $rs = $this->_conn->query( 'SHOW META;' );
 
-    // Search through the rows and find the total_found variable.
-    while ( $row = $rs->fetch_assoc() ) {
-      if ($row['Variable_name'] == 'total_found') {
-        $this->_total = $row['Value'];
-        break;
+      // Search through the rows and find the total_found variable.
+      while ( $row = $rs->fetch_assoc() ) {
+        if ($row['Variable_name'] == 'total_found') {
+          $this->_total = $row['Value'];
+          break;
+        }
       }
     }
   }
@@ -61,6 +65,17 @@ class SphinxPaginator {
   }
 
   public function getData( $limit = 25, $page = 1 ) {
+    $result = new stdClass();
+
+    // If where clause in query is empty, return 0 records instead of all.
+    if ($this->_query == "") {
+      $result->page   = $this->_page;
+      $result->limit  = $this->_limit;
+      $result->total  = $this->_total;
+      $result->data   = [];
+      return $result;
+    };
+
     $this->_limit   = $limit;
     $this->_page    = $page;
     // Add the rank function, and the field weights if the keyword or

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -973,7 +973,7 @@
         $values[] = '"' . $perf . '"';
       }
       $values = implode('|', $values);
-      $sql .= "\nWHERE MATCH('" . $values . "')";
+      if (!empty($values)) $sql .= "\nWHERE MATCH('" . $values . "')";
 
       // Only want to show unique works, not all iterations of a given work title
       $sql .= "\nGROUP BY WorkId";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -422,7 +422,7 @@
             if (is_bool($authorMatch)) {
               // When the author query returns nothing useful, there should be
               //   no matches in the main query, to match the legacy behavior.
-              array_push($queries, '0'); // Returns an empty set.
+              //array_push($queries, '0'); // Returns an empty set.
             }
             else {
               // Include the returned list of perf titles in the MATCH statement.
@@ -469,6 +469,8 @@
     // Build the WHERE clause.
     if (!empty($queries) && count($queries) > 0) {
       $sql .= "\nWHERE " . implode(' AND ', $queries);
+    } else {
+      return "";
     }
     // The results need to be grouped by Event to avoid redundancy
     $sql .= "\nGROUP BY eventid";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -386,7 +386,9 @@
             $actQry = (count($actor) > 1 && $actSwtch === "AND") ?
               getSphinxCastQuery('actor', $actor) :
               getSphinxCastQuery('actor', $actor, 'OR');
-            array_push($eventIdQueries, $actQry);
+            (empty($actQry)) ? 
+              array_merge($eventIdQueries, $actQry) :
+              array_push($eventIdQueries, $actQry);
             break;
           case 'role':
             $role = array_filter($role, 'strlen');
@@ -394,7 +396,9 @@
             $roleQry = (count($role) > 1 && $roleSwtch === "AND") ?
               getSphinxCastQuery('role', $role) :
               getSphinxCastQuery('role', $role, 'OR');
-            array_push($eventIdQueries, $roleQry);
+            (empty($roleQry)) ? 
+              array_merge($eventIdQueries, $roleQry) : 
+              array_push($eventIdQueries, $roleQry);
             break;
           case 'performance':
             $performance = mysqli_real_escape_string($sphinx_conn, $performance);


### PR DESCRIPTION
The previous bug fix indeed got rid of sql injection attempts a lot. But I still found some fetal errors in the site logs. These two bugs are not too much severe, but it's better to remove them. 

1. To test the first bug: go to the staging site, the go to the advanced search, put any long string in the field **Role**, like "this is a test". Leave all other fields in blank. Then click search. The site will show 500 error. 
2. The second bug comes from some search about **Related Work**. I tried to find an example, but failed. The error log only says an empty string shows in the WHERE clause. So, the bugfix will detect the empty string.