### PR TITLE
Resolves Faceted Search Crashes When Invalid Author, Title, or Role Are Queried

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -414,11 +414,11 @@
             //   the MATCH statement with an OR operator between each title.
             $author = trim(mysqli_real_escape_string($sphinx_conn, $author));
             $authorMatch = getSphinxAuthorQuery($author);
-            // If no authors are found, $authorMatch is false
+            // If no authors are found, $authorMatch is False
             if (!$authorMatch) {
               // When the author query returns nothing useful, there should be
               //  no matches in the main query, to match the legacy behavior.
-              array_push($queries, "authId in (-1)"); // Always false
+              array_push($queries, "authId != authId"); // Always false
             }
             else {
               // Include the returned list of perf titles in the MATCH statement.
@@ -459,7 +459,7 @@
       // If any of the eventid queries in the array are empty, the intersection will be empty
       if (empty($eventIdQueries)) {
         // If there are no event IDs, there are no valid results.
-        $eventIdQueries = 'eventid IN (-1)';
+        $eventIdQueries = 'eventid IN (-1)'; // eventid is always positive
       }
       else {
         $eventIdQueries = 'eventid IN (' . implode(', ', $eventIdQueries) . ')';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -418,7 +418,7 @@
             if (!$authorMatch) {
               // When the author query returns nothing useful, there should be
               //  no matches in the main query, to match the legacy behavior.
-              array_push($queries, "authId != authId"); // Always false
+              array_push($queries, "authId in (-1)"); // Always false
             }
             else {
               // Include the returned list of perf titles in the MATCH statement.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -414,11 +414,11 @@
             //   the MATCH statement with an OR operator between each title.
             $author = trim(mysqli_real_escape_string($sphinx_conn, $author));
             $authorMatch = getSphinxAuthorQuery($author);
-            // If the query generation encountered an error it will be false.
-            if (is_bool($authorMatch)) {
+            // If no authors are found, $authorMatch is false
+            if (!$authorMatch) {
               // When the author query returns nothing useful, there should be
-              //   no matches in the main query, to match the legacy behavior.
-              array_push($queries, '0'); // Returns an empty set.
+              //  no matches in the main query, to match the legacy behavior.
+              array_push($queries, "authId in (-1)"); // Always false
             }
             else {
               // Include the returned list of perf titles in the MATCH statement.
@@ -447,14 +447,24 @@
       //   parameter added when the title filter is set should come after.
       array_unshift($matches, "(@(perftitleclean,performancetitle) $perfTitleMatches)");
     }
-    // Build eventid IN() statement with intersect of $eventIdQueries items.
+    // Build eventid IN() statement with intersection of $eventIdQueries items.
+    // If no Actor, Role, or Author are specified, $eventIdQueries is an empty array
     if (!empty($eventIdQueries)) {
-      if (is_array($eventIdQueries) && count($eventIdQueries) === 1 && is_array($eventIdQueries[0]))
+      if (is_array($eventIdQueries) && count($eventIdQueries) === 1 && is_array($eventIdQueries[0])){
         $eventIdQueries = $eventIdQueries[0];
-      elseif (is_array($eventIdQueries[0]))
+      }
+      elseif (is_array($eventIdQueries[0])){
         $eventIdQueries = call_user_func_array('array_intersect', $eventIdQueries);
-
-      $eventIdQueries = 'eventid IN (' . implode(', ', $eventIdQueries) . ')';
+      }
+      // If any of the eventid queries in the array are empty, the intersection will be empty
+      if (empty($eventIdQueries)) {
+        // If there are no event IDs, there are no valid results.
+        $eventIdQueries = 'eventid IN (-1)';
+      }
+      else {
+        $eventIdQueries = 'eventid IN (' . implode(', ', $eventIdQueries) . ')';
+      }
+      // Push intersection (or empty set) to the queries array.
       array_push($queries, $eventIdQueries);
     }
     // Build the MATCH statement and add it to the list of queries.
@@ -477,7 +487,6 @@
     } elseif ($sortBy === 'relevance') {
       $sql .= "\nORDER BY weight() desc, eventdate asc";
     }
-
     return $sql;
   }
 


### PR DESCRIPTION
This pull request is designed to address one of the issues in [this PR](https://github.com/LondonStageDB/website/pull/65) without modifying legacy search behavior.

When testing cases that cause crashes on the current main branch, please test against the [staging server](https://cas-lndnstg-dev.uoregon.edu/search.php)  which is currently set to the website/main branch OR the main branch within the Docker container. 

## Verifying Fixes: Crashing Test Cases
### Test Case 1: Sphinx Crashes on an Author Not in the Sphinx Index 
![image](https://github.com/user-attachments/assets/5a8885cd-240d-4ff3-8ba9-e3d4fbe62a1a)

Preferred behavior: if Sphinx finds no approximate author matches, no results should be returned.

**Current Production Behavior**:  500 Internal Server Error
**After Faceted Search Fix**:  `0 results for: Author - ShakyWill` 

### Test Case 2: Sphinx Crashes on Roles Not in the Sphinx Index
![image](https://github.com/user-attachments/assets/00df283f-534e-49bc-846f-6a92bdd2b3e2)

Preferred behavior: if faceted search matches against no items in the index, no results should be returned.

**Current Production Behavior**:  500 Internal Server Error
**After Faceted Search Fix**:  `0 results for: Role - Jumbo Hamlet`

### Test Case 3: Sphinx Crashes on Roles Not in the Sphinx Index
![image](https://github.com/user-attachments/assets/db00bc0b-3b1d-4662-bbbb-86ee7a1e487a)

Preferred behavior, if faceted search matches against no items in the index, no results should be returned.

**Current Production Behavior**:  500 Internal Server Error
**After Faceted Search Fix**:  `0 results for: Actor - Conny Keyber`

### Test Case 4: Sphinx Crashes on Roles Not in the Sphinx Index with Theatre Filtering
![image](https://github.com/user-attachments/assets/e0a217a6-935a-456d-9d20-9bccff5bd00e)

Preferred behavior: if faceted search matches against no items in the index, no results should be returned.

**Current Production Behavior**:  500 Internal Server Error
**After Faceted Search Fix**:  `0 results for: Role - Otohohoho`

## Side Effect Testing: Regression Test Cases

### Test Case 1: Filtering for Roles within Events at Specific Theatres
![image](https://github.com/user-attachments/assets/5e7585c9-9ec4-4b7f-9424-3e425083315a)

**Current Production Behavior**:  `174 results for: Role - Othello`
**After Faceted Search Fix**:  `174 results for: Role - Othello`

### Test Case 2: Filtering for (Valid) Roles within Events at Specific Theatres From Plays Not Performed There
![image](https://github.com/user-attachments/assets/aee5bfda-9b06-46af-8695-4c96c76bdbdf)

**Current Production Behavior**:  ` 0 results for: Roles - John of Gaunt`
**After Faceted Search Fix**:  `0 results for: Roles - John of Gaunt`

More exhaustive testing should be performed before this pull request is merged, but any proposed change that does not pass these tests cannot be considered viable.