### PR TITLE
Related Works, Sphinx Index Adjustments

### DIFF
--- a/event.php
+++ b/event.php
@@ -198,19 +198,19 @@
                     </div>
                   <?php endif; ?>
                 </div>
-                <?php $works = getRelatedWorks($perf['PerformanceTitle']); ?>
+                <?php $works = getSphinxRelatedWorks($perf['PerformanceTitle']); ?>
                 <?php if(!empty($works) && count($works) > 0) : ?>
                 <div class="small-12 medium-5 large-4 related-works">
                   <h3>Related Works</h3>
                   <?php foreach ($works as $work) : ?>
                   <div class="work-info">
                     <div><span class="info-heading">Work Title:</span>
-                      <a href="<?php echo linkedTitles((!empty($work['Title'])) ? $work['Title'] : $work['Title'], TRUE); ?>">
-                        <?php echo (!empty($work['Title'])) ? $work['Title'] : $work['Title']; ?>
+                      <a href="<?php echo linkedTitles((!empty($work['title'])) ? $work['title'] : $work['title'], TRUE); ?>">
+                        <?php echo (!empty($work['title'])) ? $work['title'] : $work['title']; ?>
                       </a>
                     </div>
                     <div><span class="info-heading">Publish Date:</span>
-                      <?php echo $work['PubDate']; ?>
+                      <?php if($work['pubdate']) echo $work['pubdate']; ?>
                     </div>
                     <?php if (array_filter($work['author'])) : ?>
                     <?php foreach ($work['author'] as $auth) : ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2147,33 +2147,6 @@
     echo $xml;
   }
 
-
-  /**
-   * Prepares a TCP XML file from Azure for download on an event page.
-   * @param string $fn The name of the file to be downloaded
-   */
-  function getTCPFile(string $fn) {
-    # Initialize curl
-    $tcp_url = 'https://londonstage.blob.core.windows.net/lsdb-files/tcp/P4/' . $fn;
-    $ch = curl_init();
-    curl_setopt_array($ch, array(
-        CURLOPT_URL => $tcp_url,
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_HEADER => "Content-Type: text/xml",
-    ));
-
-    # Get XML file from Azure, close the connection
-    $xml = curl_exec($ch);
-    curl_close($ch);
-
-    # Prepare headers to indicate the the file is a download
-    header('Content-description: file transfer');
-    header('Content-disposition: attachment; filename=' . $fn);
-    header('Content-type: text/xml');
-    echo $xml;
-  }
-
-
   /**
   * Removes unsupported UTF8 chars from string
   *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2284,7 +2284,7 @@
       $perfs = getPerformances($event['EventId']);
 
       foreach ($perfs as $perf) {
-        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle']);
+        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'], $perf['workId']);
         $event['Performances'][] = $perf;
       }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -872,17 +872,16 @@
             'source1', 'source2', 'sourceresearched'])),
         array_column($sphinx_results, null, 'workid'));
 
-    // Populate author and tutke variant subarrays
+    // Populate author and title variant subarrays
     foreach($sphinx_results as $row) {
-      // Add authors, if any
-      if(array_key_exists('authname', $row)){
+      if(array_key_exists('authname', $row)){ // Author
         $workid = $row['workid'];
         $auth = array_intersect_key($row,
             array_flip(['authid', 'authname', 'authtype', 'startdate', 'starttype', 'enddate', 'endtype']));
         $works[$workid]['author'][$row['authid']] = array_filter($auth);
       }
       // Add title variants, if any
-      if(array_key_exists('variantname', $row)){
+      if(array_key_exists('variantname', $row)){ // Title variants
         $workid = $row['workid'];
         if (!array_key_exists( 'variantname', $works[$workid])) $works[$workid]['variantname'] = array();
         $works[$workid]['variantname'][] = $row['variantname'];
@@ -911,7 +910,7 @@
 
         if ($perfTitle !== '') $titles[] = $perfTitle; // Add performance title
 
-        // Get the structured work array identified in the performance by WorkId, if any
+        // Get the work identified in the performance by WorkId, if any
         if (!is_null($workId)) {
             $work_query = $sphinx_conn->query("SELECT *  FROM related_work WHERE workid="
                 . $workId . " GROUP BY workid, authid, variantname");

--- a/sphinx/sphinx.example.conf
+++ b/sphinx/sphinx.example.conf
@@ -95,57 +95,61 @@ source related_work
     sql_port        = 3306  # optional, default is 3306
     # Stop editing here.
     # Additional configuration to update can be found in the inxex section, below.
-    sql_query_pre   = SET @a := 1;
     sql_query       = \
-        SELECT \
-          @a := @a + 1 AS id, \
-          Works.WorkId WorkId, \
-          Works.Title Title, \
-          Works.Type1 Type1, \
-          Works.Type2 Type2, \
-          Works.Source1 Source1, \
-          Works.Source2 Source2, \
-          Works.SourceResearched SourceResearched, \
-          Works.TitleClean TitleClean, \
-          WorksVariant.VariantName VariantName, \
-          WorksVariant.NameClean, \
-          WorkAuthMaster.Title TheTitle, \
-          WorkAuthMaster.AuthType AuthType, \
-          Performances.PerfTitleClean PerfTitleClean, \
-          Performances.PerformanceTitle PerformanceTitle, \
-          Author.AuthId AuthId, \
-          Author.AuthName AuthName, \
-          Author.AuthNameClean, \
-          Author.StartDate StartDate, \
-          Author.StartType StartType, \
-          Author.EndDate EndDate, \
-          Author.EndType EndType \
-        FROM Works \
-          LEFT JOIN WorksVariant ON WorksVariant.WorkId = Works.WorkId \
-          JOIN WorkAuthMaster ON WorkAuthMaster.WorkId = Works.WorkId \
-          JOIN Author ON WorkAuthMaster.AuthId = Author.AuthId \
-          LEFT JOIN Performances ON Performances.WorkId = Works.WorkId
-    sql_field_string = TitleClean
-    sql_field_string = PerfTitleClean
-    sql_field_string = PerformanceTitle
-    sql_field_string = NameClean
-    sql_field_string = Source1
-    sql_field_string = Source2
-    sql_field_string = SourceResearched
-    sql_field_string = AuthNameClean
-    sql_attr_uint    = WorkId
-    sql_attr_string  = Title
-    sql_attr_string  = Type1
-    sql_attr_string  = Type2
-    sql_attr_string  = VariantName
-    sql_attr_string  = TheTitle
-    sql_attr_string  = AuthType
-    sql_attr_uint    = AuthId
-    sql_attr_string  = AuthName
-    sql_attr_string  = StartDate
-    sql_attr_string  = StartType
-    sql_attr_string  = EndDate
-    sql_attr_string  = EndType
+        SELECT ROW_NUMBER() OVER () AS id, sq.* \
+        FROM ( \
+            SELECT DISTINCTROW \
+                Works.WorkId AS WorkId, \
+                Works.Title AS Title, \
+                Works.PubDate AS PubDate, \
+                Works.Source1 AS Source1, \
+                Works.Source2 AS Source2, \
+                Works.SourceResearched AS SourceResearched, \
+                WorksVariant.VariantName AS VariantName, \
+                WorkAuthFiltered.AuthType AS AuthType, \
+                Author.AuthId AS AuthId, \
+                Author.AuthName AS AuthName, \
+                Author.StartDate AS StartDate, \
+                Author.StartType AS StartType, \
+                Author.EndDate AS EndDate, \
+                Author.EndType AS EndType, \
+                PerfFiltered.PerformanceTitle AS PerformanceTitle \
+            FROM Works \
+                LEFT JOIN WorksVariant \
+                ON Works.WorkId = WorksVariant.WorkId \
+                LEFT JOIN ( \
+                SELECT * FROM WorkAuthMaster \
+                WHERE AuthType LIKE "Primary" \
+                    OR AuthType LIKE "Researched" \
+                ) AS WorkAuthFiltered \
+                ON Works.WorkId = WorkAuthFiltered.WorkId \
+                LEFT JOIN Author \
+                ON WorkAuthFiltered.AuthId = Author.AuthId \
+                LEFT JOIN ( \
+                SELECT DISTINCT Works.WorkId, Performances.PerformanceTitle \
+                FROM Performances \
+                INNER JOIN Works \
+                    ON Works.WorkId = Performances.WorkId \
+                WHERE LOWER(Works.Title) != LOWER(Performances.PerformanceTitle) \
+                GROUP BY Works.WorkId \
+                ) AS PerfFiltered \
+                ON Works.WorkId = PerfFiltered.WorkId \
+            ) AS sq
+    sql_attr_uint = workid
+    sql_field_string = title
+    sql_attr_uint = pubdate
+    sql_field_string = source1
+    sql_field_string = source2
+    sql_field_string = sourceresearched
+    sql_field_string = variantname
+    sql_attr_string = authtype
+    sql_attr_uint = authid
+    sql_field_string = authname
+    sql_attr_string = startdate
+    sql_attr_string = starttype
+    sql_attr_string = enddate
+    sql_attr_string = endtype
+    sql_field_string = performancetitle
 }
 
 

--- a/sphinx/stopwords.txt
+++ b/sphinx/stopwords.txt
@@ -101,3 +101,5 @@ should
 these
 where
 within
+ou
+le


### PR DESCRIPTION
The getRelatedWorks function (SQL) and getSphinxRelatedWorks functions (SphinxQL) use different query parameters return different results. Because of this, users would often see different related works in previews on the search results page -- which used getSphinxRelatedWorks -- than they would see on the pages individual events, which used getRelatedWorks.

This PR replaces all instances of the getRelatedWorks with getSphinxRelatedWorks and optimizes the getSphinxRelatedWorks function for more precise work retrieval.

- Removes the getRelatedWorks function.
- Makes getSphinxRelatedWorks prioritize Works known to be associated with a given Performance by WorkId
- Shrinks the Sphinx related_works index from 100339 rows (~4000 unique rows) to 4624 rows.
- Adds hundreds of missing works to the index by replacing an inner join with a left join.
- Adds PubDate to the index so that the related work infobox can be populated without additional queries.
- Adds two stop words for French language titles.
- Adjusts the getSphinxAuthorQuery function to use the new related_work schema.

This PR is available for testing on the staging server.