### PR TITLE
Addresses Bugs Related to PHP Warnings, Stability Fixes 

### DIFF
--- a/event.php
+++ b/event.php
@@ -170,7 +170,7 @@
                 <div class="small-12 medium-6 large-7 perf-info-left">
                   <?php if(in_array($perf['PType'], ['p', 'a'])) : ?>
                   <div class="perf-title perf-data"><span class="info-heading">Title:</span>
-                    <a href="<?php echo linkedTitles($perf['PerformanceTitle'], TRUE); ?>">
+                    <a href="<?php echo linkedTitles($perf['PerformanceTitle']); ?>">
                       <?php echo cleanItalics(cleanTitle($perf['PerformanceTitle'])); ?>
                     </a>
                   </div>
@@ -182,9 +182,9 @@
                     <ul class="no-bullet">
                       <?php foreach ($perf['cast'] as $cast) : ?>
                       <li class="grid-x"><span class="role cell small-4"><span class="info-heading">Role:</span>
-                        <?php echo linkedSearches('role[]', $cast['Role'], TRUE); ?> </span>
+                        <?php echo linkedSearches('role[]', $cast['Role']); ?> </span>
                         <span class="actor cell small-6"><span class="info-heading">Actor:</span>
-                        <?php echo linkedSearches('actor[]', $cast['Performer'], TRUE); ?> </span>
+                        <?php echo linkedSearches('actor[]', $cast['Performer']); ?> </span>
                       </li>
                       <?php endforeach; ?>
                     </ul>
@@ -238,7 +238,9 @@
                                         if ((array_key_exists('startdate', $auth))
                                             || (array_key_exists('enddate', $auth))){
                                             // Display dates if author has at least one known date
-                                        echo "(" . $auth['startdate'] . " - " .  $auth['enddate'] .")" ; }?> </span>
+                                            $startdate = array_key_exists('startdate', $auth) ? $auth['startdate'] : '';
+                                            $enddate = array_key_exists('enddate', $auth) ? $auth['enddate'] : '';
+                                        echo "(" . $startdate . " - " .  $enddate .")" ; }?> </span>
                                 </div> <!-- end author list item -->
                               <?php endif; ?> <!--resolves if authtype is not 'Researched', 'Primary' -->
                             <?php endforeach; ?> <!-- resolves for loop for each author -->

--- a/event.php
+++ b/event.php
@@ -204,7 +204,7 @@
                   if (in_array($perf['PType'], ['d', 's', 'm', 't'])){
                       $works = array();
                   } else{
-                      $works = getSphinxRelatedWorks($perf['PerformanceTitle'], $perf['WorkId']);
+                      $works = getSphinxRelatedWorks($perf['PerfTitleClean'], $perf['WorkId']);
                   }?>
                 <?php if(!empty($works) && count($works) > 0) : ?>
                     <div class="small-12 medium-6 large-5 related-works">

--- a/event.php
+++ b/event.php
@@ -170,8 +170,8 @@
                 <div class="small-12 medium-6 large-7 perf-info-left">
                   <?php if(in_array($perf['PType'], ['p', 'a'])) : ?>
                   <div class="perf-title perf-data"><span class="info-heading">Title:</span>
-                    <a href="<?php echo linkedTitles($perf['PerformanceTitle']); ?>">
-                      <?php echo cleanItalics(cleanTitle($perf['PerformanceTitle'])); ?>
+                    <a href="<?php echo linkedTitles($perf['PerfTitleClean']); ?>">
+                      <?php echo cleanItalics(cleanTitle($perf['PerfTitleClean'])); ?>
                     </a>
                   </div>
                   <div class="perf-comments perf-data"><span>Comments:</span><br />

--- a/event.php
+++ b/event.php
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="/css/flexslider2-7-2.css" type="text/css" />
     <?php include_once('common/header.php'); ?>
     <title>London Stage Event: <?php echo formatDate($event['EventDate'], true) . ' at ' . getTheatreName($event['TheatreId']); ?></title>
-    <meta name="description" content="<?php echo formatDate($event['EventDate'], true); ?> performances of <?php echo implode(', ', array_column($event['Performances'], 'PerformanceTitle')); ?>" />
+    <meta name="description" content="<?php echo formatDate($event['EventDate'], true); ?> performances of <?php echo implode(', ', array_column($event['Performances'], 'PerfTitleClean')); ?>" />
   </head>
 
   <body id="event">

--- a/includes/act.php
+++ b/includes/act.php
@@ -1,5 +1,4 @@
 <?php
-  include_once("db.php");
   include_once('functions.php');
   global $conn;
 

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,5 +1,4 @@
 <?php
-  include_once("db.php");
   include_once('functions.php');
   global $conn;
 
@@ -10,8 +9,8 @@
   // If search string is over 3 chars, full wildcard search,
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
-    "SELECT *, (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) + case when AuthNameClean LIKE '$searchTerm' then 50 when AuthNameClean LIKE '$searchTerm%' then 15 end) as relevance FROM `author` WHERE (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) OR AuthNameClean LIKE '%$searchTerm%') GROUP BY AuthName ORDER BY relevance DESC, AuthName LIMIT 10" :
-    "SELECT * FROM `author` WHERE AuthNameClean LIKE '$searchTerm%' GROUP BY AuthName ORDER BY AuthName LIMIT 10";
+    "SELECT *, (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) + case when AuthNameClean LIKE '$searchTerm' then 50 when AuthNameClean LIKE '$searchTerm%' then 15 end) as relevance FROM Author WHERE (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) OR AuthNameClean LIKE '%$searchTerm%') GROUP BY AuthName ORDER BY relevance DESC, AuthName LIMIT 10" :
+    "SELECT * FROM Author WHERE AuthNameClean LIKE '$searchTerm%' GROUP BY AuthName ORDER BY AuthName LIMIT 10";
 
   $result = $conn->query($search);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2021,7 +2021,7 @@
  *  'actor' will take the value and link to a search for ?actor=value.
  *
  * @param string $key The key for which we will create a search link.
- * @param string $value The value for whiceh to be searched.
+ * @param string $value The value for which to be searched.
  * @param bool $sphinx_results When set to true, will like to sphinx results.
  *
  * @return string HTML Text block with values linked out to relevant searches.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2325,7 +2325,7 @@
       $perfs = getPerformances($event['EventId']);
       foreach ($perfs as $perf) {
         $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'],
-            array_key_exists('workId', $perf) ? $perf['workId'] : null);
+            array_key_exists('WorkId', $perf) ? $perf['WorkId'] : null);
         $event['Performances'][] = $perf;
       }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2325,7 +2325,7 @@
       $perfs = getPerformances($event['EventId']);
       foreach ($perfs as $perf) {
         $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'],
-            array_key_exists('workid', $perf) ? $perf['workid'] : null);
+            array_key_exists('workId', $perf) ? $perf['workId'] : null);
         $event['Performances'][] = $perf;
       }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2021,12 +2021,12 @@
  *  'actor' will take the value and link to a search for ?actor=value.
  *
  * @param string $key The key for which we will create a search link.
- * @param string $value The value for which to be searched.
+ * @param string $value The value for whiceh to be searched.
  * @param bool $sphinx_results When set to true, will like to sphinx results.
  *
  * @return string HTML Text block with values linked out to relevant searches.
  */
-  function linkedSearches($key, $value, $sphinx_results = false) {
+  function linkedSearches($key, $value) {
     $value = trim($value);
     if ($value === '') return '';
 
@@ -2039,10 +2039,7 @@
     }
 
     $re = '/' . implode('|', $m[0]) . '/i';
-    //return preg_replace($re, '<a href="results.php?'.preg_replace('/[\[\]]/', '&rbrack;', $key).'=$0">$0</a>', $value);
-    return $sphinx_results ?
-        preg_replace($re, '<a href="sphinx-results.php?'.$key.'=$0">$0</a>', $value) :
-        preg_replace($re, '<a href="results.php?'.$key.'=$0">$0</a>', $value);
+    return preg_replace($re, '<a href="sphinx-results.php?'.$key.'=$0">$0</a>', $value);
   }
 
 
@@ -2054,15 +2051,12 @@
   *
   * @return string href value.
   */
-  function linkedTitles($value, $sphinx_results = false) {
+  function linkedTitles($value) {
     $value = trim($value);
     if ($value === '') return '';
 
     $value = strip_tags(htmlentities($value));
-
-    return $sphinx_results ?
-        '/sphinx-results.php?performance=' . $value :
-        '/results.php?performance=' . $value;
+    return '/sphinx-results.php?performance=' . $value;
   }
 
 
@@ -2328,11 +2322,10 @@
     } else {
       $filename = $id;
       $event['Performances'] = array();
-      //$event['Performances'] = getPerformances($event['EventId']);
       $perfs = getPerformances($event['EventId']);
-
       foreach ($perfs as $perf) {
-        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'], $perf['workId']);
+        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'],
+            array_key_exists('workid', $perf) ? $perf['workid'] : null);
         $event['Performances'][] = $perf;
       }
     }

--- a/includes/perf.php
+++ b/includes/perf.php
@@ -1,5 +1,4 @@
 <?php
-  include_once("db.php");
   include_once('functions.php');
   global $conn;
 

--- a/includes/role.php
+++ b/includes/role.php
@@ -1,5 +1,4 @@
 <?php
-  include_once("db.php");
   include_once('functions.php');
   global $conn;
 

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -1,8 +1,5 @@
 <?php
-  $time = microtime();
-  $time = explode(' ', $time);
-  $time = $time[1] + $time[0];
-  $start = $time;
+  $start = microtime(True);
 
   include_once('includes/functions.php');
   require_once 'includes/SphinxPaginator.class.php';
@@ -19,7 +16,7 @@
   $g_p = filter_input(INPUT_GET, 'p', FILTER_SANITIZE_NUMBER_INT);
   // Prevent SQL injection
   if(!is_numeric($g_p)) $g_p = '';
-  $limit      = ( $g_lim !== '' && $g_lim > 0 ) ? $g_lim : 25;
+  $limit      = ( $g_lim !== '' && $g_lim > 0 && $g_lim <= 50) ? $g_lim : 25;
   $page       = ( $g_p !== '' && $g_p > 0 ) ? $g_p : 1;
   $links      = 3;
   $Paginator  = new SphinxPaginator( $sphinx_conn, $sql );
@@ -401,7 +398,7 @@
                          if ($inCast !== false) {
                            echo '<div class="cast"><h5>Cast</h5>';
                            foreach ($inCast as $cast) {
-                             echo '<span class="c-role"><span class="smcp"><b>Role</b></span>: ' . highlight(linkedSearches('role[]', $cast['Role']), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedRoles)) . '</span> <span class="c-act"><span class="smcp"><b>Actor</b></span>: ' . highlight(linkedSearches('actor[]', $cast['Performer'], true), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedActors)) . '</span><br>';
+                             echo '<span class="c-role"><span class="smcp"><b>Role</b></span>: ' . highlight(linkedSearches('role[]', $cast['Role']), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedRoles)) . '</span> <span class="c-act"><span class="smcp"><b>Actor</b></span>: ' . highlight(linkedSearches('actor[]', $cast['Performer']), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedActors)) . '</span><br>';
                            }
                            echo '</div>';
                          }
@@ -474,11 +471,8 @@
   <!--
 
   <?php
-  $time = microtime();
-  $time = explode(' ', $time);
-  $time = $time[1] + $time[0];
-  $finish = $time;
-  $total_time = round(($finish - $start), 4);
+  $finish = microtime(True);
+  $total_time = round($finish - $start, 4);
   echo "Page generated in $total_time seconds.";
   ?>
 

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -472,7 +472,7 @@
 
   <?php
   $finish = microtime(True);
-  $total_time = round($finish - $start, 4);
+  $total_time = round(($finish - $start), 4);
   echo "Page generated in $total_time seconds.";
   ?>
 

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -401,7 +401,7 @@
                          if ($inCast !== false) {
                            echo '<div class="cast"><h5>Cast</h5>';
                            foreach ($inCast as $cast) {
-                             echo '<span class="c-role"><span class="smcp"><b>Role</b></span>: ' . highlight(linkedSearches('role[]', $cast['Role'], true), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedRoles)) . '</span> <span class="c-act"><span class="smcp"><b>Actor</b></span>: ' . highlight(linkedSearches('actor[]', $cast['Performer'], true), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedActors)) . '</span><br>';
+                             echo '<span class="c-role"><span class="smcp"><b>Role</b></span>: ' . highlight(linkedSearches('role[]', $cast['Role']), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedRoles)) . '</span> <span class="c-act"><span class="smcp"><b>Actor</b></span>: ' . highlight(linkedSearches('actor[]', $cast['Performer'], true), cleanQuotes($keyword) . '|' . cleanQuotes($cleanedActors)) . '</span><br>';
                            }
                            echo '</div>';
                          }


### PR DESCRIPTION
### Old Bugs

#### Faceted Search
I have done a cursory fix on `auth.php`, but this function (and role.php, perf.php) should be rewritten to use Sphinx rather than vanilla SQL in a future iteration.

**Redundant Imports**
- Fixes redundant imports in auth.php, role.php, perf.php
  - db.php should be imported exactly once, so there is no need to import both functions.php (imports db.php) **and** db.php

**Fatal SQL Query Error**
- Fixes table capitalization from author -> Author in auth.php

**Page Limit Hacks**
- Prevents users from loading more than 50 results per results page at a time in their browser through the limit parameter specified in the URL.
- Without this line, arbitrary numbers of results can be queried through the Sphinx results page.

**Typing Error**
- Fixes an error with microtime being returned as a string rather than as a float.

### Related Witnesses Bugs

event.php
- Fixes indexing behavior of authors with startdates but no enddates and vice-versa
- Prevents passing messy performance titles to getSphinxRelatedWorks

Available for testing on staging. Tested on both Docker and staging.
