### PR TITLE
Prevents Queries and Regular Expressions Against The PerformanceTitle Field

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -444,7 +444,7 @@
       $perfTitleMatches = implode(' ', $perfTitleMatches);
       // Place the new string at the beginning of the array because the MAYBE
       //   parameter added when the title filter is set should come after.
-      array_unshift($matches, "(@(perftitleclean) $perfTitleMatches)");
+      array_unshift($matches, "(@(perftitleclean,performancetitle) $perfTitleMatches)");
     }
     // Build eventid IN() statement with intersection of $eventIdQueries items.
     // If no Actor, Role, or Author are specified, $eventIdQueries is an empty array

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -608,7 +608,7 @@
         if ($row['Variable_name'] === 'total_found')
           $all_counts[] = ['col' => 'eccount', 'count' => $row['Value']];
 
-    if (!is_bool($result['c_meta']) && !is_bool($result['c_meta']))
+    if (!is_bool($result['c']) && !is_bool($result['c_meta']))
       while ($row = $result['c_meta']->fetch_assoc())
         if ($row['Variable_name'] === 'total_found')
           $all_counts[] = ['col' => 'ccount', 'count' => $row['Value']];
@@ -1507,12 +1507,13 @@
         $workTitles[] = $row['title'];
       if ($row['variantname'] && $row['variantname'] !== '')
         $workTitles[] = $row['variantname'];
-      if ($row['performancetitle'] && $row['performancetitle'] !== '')
-        $workTitles[] = $row['performancetitle'];
+      // TODO(emwin) Add back with unicode Sphinx index change
+      /* if ($row['perftitleclean'] !== '')
+        $workTitles[] = $row['perftitleclean']; */
     }
     if (empty($workTitles)) return FALSE;
     // Unique list of all titles.
-    $titles = array_unique($workTitles);
+    $titles = array_unique(array_map('ucwords', $workTitles));
     // Some titles actually contain multiple titles, separated by a semicolon or
     //   '; or '. We'll trim and explode out the title on the semicolon, and
     //   $prefix is used to strip out the 'or '.
@@ -2324,7 +2325,7 @@
       $event['Performances'] = array();
       $perfs = getPerformances($event['EventId']);
       foreach ($perfs as $perf) {
-        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle'],
+        $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerfTitleClean'],
             array_key_exists('WorkId', $perf) ? $perf['WorkId'] : null);
         $event['Performances'][] = $perf;
       }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -444,7 +444,7 @@
       $perfTitleMatches = implode(' ', $perfTitleMatches);
       // Place the new string at the beginning of the array because the MAYBE
       //   parameter added when the title filter is set should come after.
-      array_unshift($matches, "(@(perftitleclean,performancetitle) $perfTitleMatches)");
+      array_unshift($matches, "@perftitleclean $perfTitleMatches)");
     }
     // Build eventid IN() statement with intersection of $eventIdQueries items.
     // If no Actor, Role, or Author are specified, $eventIdQueries is an empty array

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -444,7 +444,7 @@
       $perfTitleMatches = implode(' ', $perfTitleMatches);
       // Place the new string at the beginning of the array because the MAYBE
       //   parameter added when the title filter is set should come after.
-      array_unshift($matches, "@perftitleclean $perfTitleMatches)");
+      array_unshift($matches, "(@(perftitleclean) $perfTitleMatches)");
     }
     // Build eventid IN() statement with intersection of $eventIdQueries items.
     // If no Actor, Role, or Author are specified, $eventIdQueries is an empty array

--- a/includes/perf.php
+++ b/includes/perf.php
@@ -9,8 +9,8 @@
   // If search string is over 3 chars, full wildcard search,
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
-    "SELECT *, (MATCH(PerfTitleClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) + case when PerfTitleClean LIKE '$searchTerm' then 50 when PerfTitleClean LIKE '$searchTerm%' then 15 end) as relevance FROM `Performances` WHERE (MATCH(PerfTitleClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) OR PerfTitleClean LIKE '%$searchTerm%') GROUP BY PerformanceTitle ORDER BY relevance DESC, PerformanceTitle LIMIT 10" :
-    "SELECT * FROM `Performances` WHERE PerfTitleClean LIKE '$searchTerm%' GROUP BY PerformanceTitle ORDER BY PerformanceTitle LIMIT 10";
+    "SELECT PerfTitleClean, (MATCH(PerfTitleClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) + case when PerfTitleClean LIKE '$searchTerm' then 50 when PerfTitleClean LIKE '$searchTerm%' then 15 end) as relevance FROM `Performances` WHERE (MATCH(PerfTitleClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) OR PerfTitleClean LIKE '%$searchTerm%') GROUP BY PerfTitleClean ORDER BY relevance DESC, PerfTitleClean LIMIT 10" :
+    "SELECT PerfTitleClean FROM `Performances` WHERE PerfTitleClean LIKE '$searchTerm%' GROUP BY PerfTitleClean ORDER BY PerfTitleClean LIMIT 10";
 
   $result = $conn->query($search);
 

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -386,7 +386,7 @@
                         if (in_array($perf['PType'], ['a', 'p'])) {
                             $to_highlight = isset($_GET['keyword']) ? cleanQuotes($_GET['keyword']) : '';
                             $to_highlight .= (!empty($_GET['performance'])) ? '|' . cleanQuotes($_GET['performance']) : '';
-                            echo '<i>' . highlight(cleanItalics(cleanTitle($perf['PerformanceTitle'])), !empty($to_highlight) ? $to_highlight : NULL) . '</i>';
+                            echo '<i>' . highlight(cleanItalics(cleanTitle($perf['PerfTitleClean'])), !empty($to_highlight) ? $to_highlight : NULL) . '</i>';
                         } else {
                             echo highlight(namedEntityLinks($perf['DetailedComment'], true), !empty($to_highlight) ? $to_highlight : NULL);
                         }

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -377,7 +377,7 @@
                       <h3>Performances</h3>
                       <?php foreach ($results->data[$i]['performances'] as $perf) {
                         if ((isset($_GET['author']) && trim($_GET['author']) !== '') || (isset($_GET['keyword']) && trim($_GET['keyword']) !== '')) {
-                            $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle']);
+                            $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerfTitleClean']);
                         }
                         echo '<div class="perf">';
                         echo '<h4><span class="info-heading">' . getPType($perf['PType']) . (in_array($perf['PType'], ['a', 'p']) ? ' Title' : '') . ': </span>';


### PR DESCRIPTION
Prevents `PHP Warning:  preg_replace(): Compilation failed:` errors by preventing PerformanceTitle (field has too many special characters to use) from being compiled into regular expressions.

I will add PerfTitleClean back into the Sphinx index in a later PR, but I wanted to a change that was easy to test and roll out.

Events linked to Performances with problematic PerformanceTitle values (special characters, html) to test against:
49583
39353

Tested on Docker and Staging. Currently available for testing on Staging.