### PR TITLE
Reverts Display Titles in event.php

### DIFF
--- a/event.php
+++ b/event.php
@@ -170,8 +170,8 @@
                 <div class="small-12 medium-6 large-7 perf-info-left">
                   <?php if(in_array($perf['PType'], ['p', 'a'])) : ?>
                   <div class="perf-title perf-data"><span class="info-heading">Title:</span>
-                    <a href="<?php echo linkedTitles($perf['PerfTitleClean']); ?>">
-                      <?php echo cleanItalics(cleanTitle($perf['PerfTitleClean'])); ?>
+                    <a href="<?php echo linkedTitles($perf['PerformanceTitle']); ?>">
+                      <?php echo cleanItalics(cleanTitle($perf['PerformanceTitle'])); ?>
                     </a>
                   </div>
                   <div class="perf-comments perf-data"><span>Comments:</span><br />


### PR DESCRIPTION
Reverts display titles in event.php to a version of the PerformanceTitle field with HTML stripped out, while making sure only PerfTitleClean or cleaned titles are queried against Sphinx.

Tested in Docker and available for testing on staging.

Reverts current prod behavior (A) to  its former behavior (B)
A. _The Unhappy Favourite Or The Earl Of Essex_
B. _The Unhappy Favourite; Or, The Earl Of Essex_ 