### PR TITLE
Consistent Unicode Handling and Retrieval in Author Names, New Author Index

### DIFF
--- a/event.php
+++ b/event.php
@@ -170,8 +170,8 @@
                 <div class="small-12 medium-6 large-7 perf-info-left">
                   <?php if(in_array($perf['PType'], ['p', 'a'])) : ?>
                   <div class="perf-title perf-data"><span class="info-heading">Title:</span>
-                    <a href="<?php echo linkedTitles($perf['PerfTitleClean']); ?>">
-                      <?php echo cleanItalics(cleanTitle($perf['PerfTitleClean'])); ?>
+                    <a href="<?php echo linkedTitles($perf['PerformanceTitle']); ?>">
+                      <?php echo cleanItalics(cleanTitle($perf['PerformanceTitle'])); ?>
                     </a>
                   </div>
                   <div class="perf-comments perf-data"><span>Comments:</span><br />

--- a/event.php
+++ b/event.php
@@ -45,7 +45,7 @@
             <?php echo $event['Volume']; ?>
           </div>
           <div class="event-comments"><span class="info-heading">Comments:</span>
-            <?php echo namedEntityLinks($event['CommentC'], TRUE); ?>
+            <?php echo namedEntityLinks($event['CommentC']); ?>
           </div>
           <div class="event-btns grid-x">
             <div class="work-nav small-12 medium-6 large-6">
@@ -175,7 +175,7 @@
                     </a>
                   </div>
                   <div class="perf-comments perf-data"><span>Comments:</span><br />
-                    <?php echo namedEntityLinks($perf['CommentP'], TRUE); ?>
+                    <?php echo namedEntityLinks($perf['CommentP']); ?>
                   </div>
                   <div class="perf-cast perf-data"><span>Cast:</span><br />
                     <?php if (count($perf['cast']) > 0) : ?>
@@ -194,7 +194,7 @@
                   </div>
                   <?php else : ?>
                     <div class="perf-comments perf-data"><span class="info-heading">Comment:</span>
-                      <?php echo namedEntityLinks($perf['DetailedComment'], TRUE); ?>
+                      <?php echo namedEntityLinks($perf['DetailedComment']); ?>
                     </div>
                   <?php endif; ?>
                 </div>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -10,13 +10,13 @@
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
     "select authname from author where MATCH('$searchTerm*') LIMIT 10" :
-    "select authname from author where MATCH('*$searchTerm*')";
+    "select authname from author where MATCH('*$searchTerm*') LIMIT 10";
 
-  $result = $spihx_conn->query($search);
+  $result = $sphinx_conn->query($search);
 
   $data = array();
   while ($row = $result->fetch_assoc()) {
-    $data[] = trim($row['AuthName']);
+    $data[] = trim($row['authname']);
   }
 
   echo json_encode(array_unique($data));

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -9,16 +9,18 @@
   // If search string is over 3 chars, full wildcard search,
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
-    "select authname, variantname from author where MATCH('$searchTerm*') LIMIT 10" :
-    "select authname, variantname from author where MATCH('*$searchTerm*') LIMIT 10";
+    "select authname, authnameclean from author 
+                               where MATCH('@(authname,authnameclean) $searchTerm*') LIMIT 10" :
+    "select authname, authnameclean from author 
+                               where MATCH('@(authname,authnameclean) *$searchTerm*') LIMIT 10";
 
   $result = $sphinx_conn->query($search);
 
   $names = array();
   while ($row = $result->fetch_assoc()) {
     $names[] = trim($row['authname']);
-    if (!empty($row['variantname'])) {
-      $names[] = $row['variantname'];
+    if (!empty($row['authnameclean'])) {
+      $names[] = $row['authnameclean'];
     }
   }
   echo json_encode(array_unique($names));

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,18 +1,18 @@
 <?php
   include_once('functions.php');
-  global $conn;
+  global $sphinx_conn;
 
   $searchTerm = $_GET['term'];
   $searchTerm = cleanStr($searchTerm);
-  $searchTerm = mysqli_real_escape_string($conn, $searchTerm);
+  $searchTerm = mysqli_real_escape_string($sphinx_conn, $searchTerm);
 
   // If search string is over 3 chars, full wildcard search,
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
-    "SELECT *, (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) + case when AuthNameClean LIKE '$searchTerm' then 50 when AuthNameClean LIKE '$searchTerm%' then 15 end) as relevance FROM Author WHERE (MATCH(AuthNameClean) AGAINST ('\"$searchTerm\" @4' IN BOOLEAN MODE) OR AuthNameClean LIKE '%$searchTerm%') GROUP BY AuthName ORDER BY relevance DESC, AuthName LIMIT 10" :
-    "SELECT * FROM Author WHERE AuthNameClean LIKE '$searchTerm%' GROUP BY AuthName ORDER BY AuthName LIMIT 10";
+    "select authname from author where MATCH('$searchTerm*') LIMIT 10" :
+    "select authname from author where MATCH('*$searchTerm*')";
 
-  $result = $conn->query($search);
+  $result = $spihx_conn->query($search);
 
   $data = array();
   while ($row = $result->fetch_assoc()) {

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -9,15 +9,17 @@
   // If search string is over 3 chars, full wildcard search,
   // Else exact match beginning of string with wildcard at the end
   $search = strlen($searchTerm) > 3 ?
-    "select authname from author where MATCH('$searchTerm*') LIMIT 10" :
-    "select authname from author where MATCH('*$searchTerm*') LIMIT 10";
+    "select authname, variantname from author where MATCH('$searchTerm*') LIMIT 10" :
+    "select authname, variantname from author where MATCH('*$searchTerm*') LIMIT 10";
 
   $result = $sphinx_conn->query($search);
 
-  $data = array();
+  $names = array();
   while ($row = $result->fetch_assoc()) {
-    $data[] = trim($row['authname']);
+    $names[] = trim($row['authname']);
+    if (!empty($row['variantname'])) {
+      $names[] = $row['variantname'];
+    }
   }
-
-  echo json_encode(array_unique($data));
+  echo json_encode(array_unique($names));
 ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -568,7 +568,7 @@
    */
   function getSphinxResultsByColumn($keyword) {
     global $sphinx_conn;
-    $keywrd   = mysqli_real_escape_string($sphinx_conn, cleanQuotes($keyword));
+    $keywrd   = mysqli_real_escape_string($sphinx_conn, $keyword);
     $psql     = "SELECT performanceid FROM london_stages WHERE MATCH('@perftitleclean \"$keywrd\"/1') GROUP BY performanceid";
     $asql     = "SELECT eventid FROM london_stages WHERE MATCH('@authnameclean \"$keywrd\"/1') GROUP BY eventid";
     $pcsql    = "SELECT performanceid FROM london_stages WHERE MATCH('@commentpclean \"$keywrd\"/1') GROUP BY performanceid";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2128,7 +2128,7 @@
               $subnode = $xml_data->addChild($key);
               array_to_xml($value, $subnode, $key);
           } else {
-              $xml_data->addChild("$key",htmlspecialchars(utf8_for_xml("$value")));
+              $xml_data->addChild("$key",htmlspecialchars("$value"));
           }
        }
      }
@@ -2176,7 +2176,7 @@
               $subnode = $xml_data->addChild($key);
               array_to_xml($value, $subnode, $key);
           } else {
-              $xml_data->addChild("$key",htmlspecialchars(utf8_for_xml("$value")));
+              $xml_data->addChild("$key",htmlspecialchars("$value"));
           }
        }
      }
@@ -2215,19 +2215,6 @@
     header('Content-type: text/xml');
     echo $xml;
   }
-
-
-  /**
-  * Removes unsupported UTF8 chars from string
-  *
-  * @param string $string String that needs to be prepared for XML conversion.
-  *
-  * @return string
-  */
-  function utf8_for_xml($string) {
-    return preg_replace ('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $string);
-  }
-
 
   /**
   * Creates CSV download for all search results
@@ -2288,7 +2275,7 @@
     $fp = fopen('php://output', 'w');
     // Set headers so file automatically downloads
     header('Content-disposition: attachment; filename=' . $filename . '.csv');
-    header('Content-type: text/csv; charset=utf-8');
+    header('Content-type: text/csv; charset=utf8mb4');
     if(empty($ids)) {
       fputcsv($fp, 'No Events Found');
     } else {
@@ -2297,9 +2284,6 @@
         if(empty($headers)) {
           $headers = array_keys($row);
           fputcsv($fp, $headers);
-        }
-        foreach($row as $key => $value) {
-          $row[$key] = utf8_for_xml($value);
         }
         fputcsv($fp, $row);
       }
@@ -2330,7 +2314,7 @@
       }
     }
 
-    $json = json_encode(utf8ize($event));
+    $json = json_encode($event);
 
     // Set headers so file automatically downloads
     header('Content-disposition: attachment; filename=' . $filename . '.json');
@@ -2357,7 +2341,7 @@
     }
 
     if (count($ids) < 2000) {
-      $json = json_encode(utf8ize($events));
+      $json = json_encode($events);
     } else {
       $json = encodeLargeArray($events);
     }
@@ -2385,7 +2369,7 @@
     $json = array();
     while (count($events) > 0) {
         $partial_array = array_slice($events, 0, $threshold);
-        $json[] = ltrim(rtrim(json_encode(utf8ize($partial_array)), "]"), "[");
+        $json[] = ltrim(rtrim(json_encode($partial_array), "]"), "[");
         $events = array_slice($events, $threshold);
     }
 
@@ -2398,20 +2382,6 @@
     }
     $jsonStr2 = '[' . $jsonStr . ']';
     return $jsonStr2;
-  }
-
-
-
-
-  function utf8ize($d) {
-    if (is_array($d)) {
-        foreach ($d as $k => $v) {
-            $d[$k] = utf8ize($v);
-        }
-    } else if (is_string ($d)) {
-        return utf8_encode($d);
-    }
-    return $d;
   }
 
 ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1495,8 +1495,7 @@
 
     // Get candidate author ids
     $authIdQuery = "SELECT authid 
-        FROM author
-        WHERE MATCH('$authorClean') 
+        FROM author WHERE MATCH('@(authname,authnameclean) $authorClean') 
         GROUP BY authid LIMIT 10";
     $result = $sphinx_conn->query($authIdQuery);
     if (!$result) return FALSE;
@@ -1508,7 +1507,7 @@
     if (empty($authids)) return FALSE;
 
     $authorWorksSql =
-        "SELECT *
+        "SELECT title, variantname, perftitleclean
          FROM related_work
          WHERE authid IN (" . implode(', ', $authids) . ")
          GROUP BY workid
@@ -1890,6 +1889,7 @@
     $allWords = array_filter($allWords, function($werd) {
       return strlen($werd) > 2;
     });
+    $allWords = array_unique($allWords);
 
     $re = '/\\w*?' . implode('|', $allWords) . '\\w*/i';
     if(!preg_match($re, $text)) {
@@ -2021,15 +2021,13 @@
  *
  * @return string HTML Text block with named entities linked out to keyword searches
  */
-  function namedEntityLinks($text, $sphinx_results = false) {
+  function namedEntityLinks($text) {
     $text = trim($text);
     if ($text === "") return '';
 
     $re = '/(\$)([\s\S]+)(=)([^\"]*)/U'; // Matches $name=
 
-    return $sphinx_results ?
-        preg_replace($re, '<a href="/sphinx-results.php?keyword=$2">$2$4</a>', $text) :
-        preg_replace($re, '<a href="/results.php?keyword=$2">$2$4</a>', $text);
+    return preg_replace($re, '<a href="/sphinx-results.php?keyword=$2">$2$4</a>', $text);
   }
 
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -669,7 +669,7 @@
       $string = array_map('strip_tags', $string);
     }
 
-    return preg_replace('/[^A-Za-z0-9 ;"]/', '', $string);
+    return preg_replace('/[^\p{L} ;"]/u', '', $string);
   }
 
 

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -377,7 +377,7 @@
                       <h3>Performances</h3>
                       <?php foreach ($results->data[$i]['performances'] as $perf) {
                         if ((isset($_GET['author']) && trim($_GET['author']) !== '') || (isset($_GET['keyword']) && trim($_GET['keyword']) !== '')) {
-                            $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerformanceTitle']);
+                            $perf['RelatedWorks'] = getSphinxRelatedWorks($perf['PerfTitleClean'], $perf['WorkId']);
                         }
                         echo '<div class="perf">';
                         echo '<h4><span class="info-heading">' . getPType($perf['PType']) . (in_array($perf['PType'], ['a', 'p']) ? ' Title' : '') . ': </span>';
@@ -414,7 +414,8 @@
                                   $keyword = isset($_GET['keyword']) ? $_GET['keyword'] : '';
                                   // Skip over comparing search terms to authors with no known name
                                   if (!array_key_exists('authname', $rltdAuth)) continue; 
-                                  if (isFoundIn($rltdAuth['authname'], cleanQuotes(cleanStr($keyword)) . '|' . cleanQuotes(cleanStr($author)))) {
+                                  if (isFoundIn($rltdAuth['authname'], cleanQuotes(cleanStr($keyword)) .
+                                      '|' . cleanQuotes(cleanStr($author)))) {
                                     $isFoundInRelated = true;
                                     if (!in_array($rltd['title'], $isFoundUnique)) {
                                       $isFoundUnique[] = $rltd['title'];

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -371,7 +371,7 @@
                   </h2>
                 </div>
                 <div class="evt-body">
-                  <?php if (isset($_GET['keyword']) && isFoundIn($results->data[$i]['commentc'], cleanQuotes(cleanStr($_GET['keyword'])))) echo '<div class="evt-info"><b>Event Comment: </b>' . highlight(namedEntityLinks($results->data[$i]['commentc'], true), cleanQuotes($_GET['keyword'])) . '</div>';?>
+                  <?php if (isset($_GET['keyword']) && isFoundIn($results->data[$i]['commentc'], cleanQuotes(cleanStr($_GET['keyword'])))) echo '<div class="evt-info"><b>Event Comment: </b>' . highlight(namedEntityLinks($results->data[$i]['commentc']), cleanQuotes($_GET['keyword'])) . '</div>';?>
                   <div class="evt-other clearfix">
                     <div class="perfs">
                       <h3>Performances</h3>
@@ -388,10 +388,10 @@
                             $to_highlight .= (!empty($_GET['performance'])) ? '|' . cleanQuotes($_GET['performance']) : '';
                             echo '<i>' . highlight(cleanItalics(cleanTitle($perf['PerformanceTitle'])), !empty($to_highlight) ? $to_highlight : NULL) . '</i>';
                         } else {
-                            echo highlight(namedEntityLinks($perf['DetailedComment'], true), !empty($to_highlight) ? $to_highlight : NULL);
+                            echo highlight(namedEntityLinks($perf['DetailedComment']), !empty($to_highlight) ? $to_highlight : NULL);
                         }
                         echo '</h4>';
-                        if (isset($_GET['keyword']) && isFoundIn($perf['CommentP'], cleanQuotes(cleanStr($_GET['keyword']))) ) echo '<span class="perf-comm"><span class="smcp"><b>Performance Comment: </b></span>' . highlight(namedEntityLinks($perf['CommentP'], true), cleanQuotes($_GET['keyword'])) . '</span><br>';
+                        if (isset($_GET['keyword']) && isFoundIn($perf['CommentP'], cleanQuotes(cleanStr($_GET['keyword']))) ) echo '<span class="perf-comm"><span class="smcp"><b>Performance Comment: </b></span>' . highlight(namedEntityLinks($perf['CommentP']), cleanQuotes($_GET['keyword'])) . '</span><br>';
                         echo '<div class="perf-body">';
                         $keyword = isset($_GET['keyword']) ? $_GET['keyword'] : '';
                          $inCast = isInCast(cleanQuotes($keyword) . '|' . cleanQuotes($cleanedActors), cleanQuotes(cleanStr($keyword)) . '|' . cleanQuotes($cleanedRoles), $perf['cast']);

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -19,7 +19,7 @@
   $g_p = filter_input(INPUT_GET, 'p', FILTER_SANITIZE_NUMBER_INT);
   // Prevent SQL injection
   if(!is_numeric($g_p)) $g_p = '';
-  $limit      = ( $g_lim !== '' && $g_lim > 0 ) ? $g_lim : 25;
+  $limit      = ( $g_lim !== '' && $g_lim > 0 && $g_lim <= 50) ? $g_lim : 25;
   $page       = ( $g_p !== '' && $g_p > 0 ) ? $g_p : 1;
   $links      = 3;
   $Paginator  = new SphinxPaginator( $sphinx_conn, $sql );

--- a/sphinx/sphinx.example.conf
+++ b/sphinx/sphinx.example.conf
@@ -18,8 +18,9 @@ source main
     # Additional configuration to update can be found in the next Source definition.
     sql_query_pre   = SET @a := 1;
     sql_query       = \
-        SELECT \
-          @a := @a + 1 AS id, \
+        SELECT ROW_NUMBER() OVER () AS id, sq.* \
+        FROM ( \
+            SELECT DISTINCTROW \
           Events.EventId eventid, \
           Events.EventDate eventdate, \
           Events.Season season, \
@@ -46,7 +47,8 @@ source main
           Works.WorkId workid, \
           Author.AuthId authid, \
           Author.AuthName authname, \
-          Author.AuthNameClean authnameclean \
+          Author.AuthNameClean authnameclean, \
+          AuthorVariant.VariantName authvariant \
         FROM Events \
           LEFT JOIN Performances ON Performances.EventId = Events.EventId \
           LEFT JOIN Cast ON Cast.PerformanceId = Performances.PerformanceId \
@@ -54,7 +56,8 @@ source main
           LEFT JOIN Works ON Works.WorkId = Performances.WorkId \
           LEFT JOIN WorkAuthMaster on WorkAuthMaster.WorkId = Works.WorkId \
           LEFT JOIN Author on Author.AuthId = WorkAuthMaster.AuthId \
-          LEFT JOIN WorksVariant ON WorksVariant.WorkId = Works.WorkId
+          LEFT JOIN AuthorVariant on AuthorVariant.Authid = Author.AuthId \
+          LEFT JOIN WorksVariant ON WorksVariant.WorkId = Works.WorkId ) as sq
     sql_field_string = commentcclean
     sql_field_string = perftitleclean
     sql_field_string = performancetitle
@@ -62,6 +65,8 @@ source main
     sql_field_string = roleclean
     sql_field_string = performerclean
     sql_field_string = authnameclean
+    sql_field_string = authname
+    sql_field_string = authvariant
     sql_attr_uint    = eventid
     sql_attr_uint    = eventdate
     sql_attr_string  = season
@@ -81,7 +86,6 @@ source main
     sql_attr_string  = theatrename
     sql_attr_uint    = workid
     sql_attr_uint    = authid
-    sql_attr_string  = authname
 }
 
 source related_work
@@ -113,7 +117,8 @@ source related_work
                 Author.StartType AS StartType, \
                 Author.EndDate AS EndDate, \
                 Author.EndType AS EndType, \
-                PerfFiltered.PerformanceTitle AS PerformanceTitle \
+                PerfFiltered.PerformanceTitle AS PerformanceTitle, \
+                PerfFiltered.PerfTitleClean AS PerfTitleClean \
             FROM Works \
                 LEFT JOIN WorksVariant \
                 ON Works.WorkId = WorksVariant.WorkId \
@@ -126,7 +131,8 @@ source related_work
                 LEFT JOIN Author \
                 ON WorkAuthFiltered.AuthId = Author.AuthId \
                 LEFT JOIN ( \
-                SELECT DISTINCT Works.WorkId, Performances.PerformanceTitle \
+                SELECT DISTINCT Works.WorkId, Performances.PerformanceTitle, \
+                Performances.PerfTitleClean \
                 FROM Performances \
                 INNER JOIN Works \
                     ON Works.WorkId = Performances.WorkId \
@@ -134,7 +140,7 @@ source related_work
                 GROUP BY Works.WorkId \
                 ) AS PerfFiltered \
                 ON Works.WorkId = PerfFiltered.WorkId \
-            ) AS sq
+            ) AS sq 
     sql_attr_uint = workid
     sql_field_string = title
     sql_attr_uint = pubdate
@@ -150,6 +156,7 @@ source related_work
     sql_attr_string = enddate
     sql_attr_string = endtype
     sql_field_string = performancetitle
+    sql_field_string = perftitleclean
 }
 
 
@@ -163,7 +170,7 @@ index london_stages
     path            = /opt/sphinx/index/london_stages
     # The location of the stopwords file should be entered below.
     stopwords       = /opt/sphinx/conf/stopwords.txt
-        # Unicode character mapping settings
+    # Unicode character mapping settings
     charset_table = 0..9, A..Z->a..z, a..z, \
                     U+00C2->A, U+00C3->A, \
                     U+00C9->E, \
@@ -175,6 +182,49 @@ index london_stages
                     U+00F9->u, U+00FC->u, U+00FA->u
     # Stop editing here.
     # Additional configuration to update can be found in the next inxex section.
+}
+
+# Auto-complete index for author names
+source author
+{
+    type            = mysql
+    sql_host        = mysqlhost.example.com # can be localhost
+    sql_user        = londonstagedbuser
+    sql_pass        = areallysecurepassword1A!
+    sql_db          = London
+    sql_port        = 3306  # optional, default is 3306
+    sql_query       = \
+        SELECT \
+            ROW_NUMBER() OVER () AS id, \
+            Author.AuthId authid, \
+            Author.AuthName authname, \
+            Author.AuthNameClean authnameclean, \
+            AuthorVariant.VariantName authvariant \
+            from Author \
+            LEFT JOIN AuthorVariant \
+                on Author.AuthId = AuthorVariant.AuthId;
+    sql_attr_uint    = authid
+    sql_field_string = authname
+    sql_field_string = authnameclean
+    sql_field_string = authvariant
+}
+
+index author
+{
+    source          = author
+    path            = /opt/sphinx/index/author
+    charset_table   = 0..9, A..Z->a..z, a..z, \
+                    U+00C2->A, U+00C3->A, \
+                    U+00C9->E, \
+                    U+00E0->a, U+00E1->a, U+00E2->a, U+00E4->a, U+00E5->a, \
+                    U+00E7->c, \
+                    U+00E8->e, U+00E9->e, U+00EA->e, \
+                    U+00EE->i, U+00EF->i, \
+                    U+00F2->o, U+00F3->o, U+00F4->o, U+00F5->o, U+00F6->o, \
+                    U+00F9->u, U+00FC->u, U+00FA->u
+    min_prefix_len = 1
+    expand_keywords = 0
+
 }
 
 index related_work

--- a/sphinx/sphinx.example.conf
+++ b/sphinx/sphinx.example.conf
@@ -163,6 +163,16 @@ index london_stages
     path            = /opt/sphinx/index/london_stages
     # The location of the stopwords file should be entered below.
     stopwords       = /opt/sphinx/conf/stopwords.txt
+        # Unicode character mapping settings
+    charset_table = 0..9, A..Z->a..z, a..z, \
+                    U+00C2->A, U+00C3->A, \
+                    U+00C9->E, \
+                    U+00E0->a, U+00E1->a, U+00E2->a, U+00E4->a, U+00E5->a, \
+                    U+00E7->c, \
+                    U+00E8->e, U+00E9->e, U+00EA->e, \
+                    U+00EE->i, U+00EF->i, \
+                    U+00F2->o, U+00F3->o, U+00F4->o, U+00F5->o, U+00F6->o, \
+                    U+00F9->u, U+00FC->u, U+00FA->u
     # Stop editing here.
     # Additional configuration to update can be found in the next inxex section.
 }
@@ -176,6 +186,16 @@ index related_work
     path            = /opt/sphinx/index/related_work
     # The location of the stopwords file should be entered below.
     stopwords       = /opt/sphinx/conf/stopwords.txt
+        # Unicode character mapping settings
+    charset_table = 0..9, A..Z->a..z, a..z, \
+                    U+00C2->A, U+00C3->A, \
+                    U+00C9->E, \
+                    U+00E0->a, U+00E1->a, U+00E2->a, U+00E4->a, U+00E5->a, \
+                    U+00E7->c, \
+                    U+00E8->e, U+00E9->e, U+00EA->e, \
+                    U+00EE->i, U+00EF->i, \
+                    U+00F2->o, U+00F3->o, U+00F4->o, U+00F5->o, U+00F6->o, \
+                    U+00F9->u, U+00FC->u, U+00FA->u
     # Stop editing here.
     # Additional configuration to update can be found in the next inxex section.
 }


### PR DESCRIPTION
- Replaces a SQL query in auth.php to queries against a new Sphinx author index
- Defines a new Sphinx author index, adds unicode mapping to existing indices
- Tweaks the search by author algorithm to no longer strip out accented characters when querying or displaying
- Adds variant names from the AuthVariant table to that index for future development work
- Uses Sphinx's charset table feature to map of unicode characters identified in author names, like the unicode è to e and vice-versa at search time: search for Moliere or Molière and get the same results!
- The database is utf8mb4 compliant now afaict; this PR removes redundant utf8 encoding functions
 
This feature cannot be used against PerformanceTitles yet, as we need to scrub residual HTML and other invalid character strings from them. The Sphinx change must be rolled out to staging through Puppet, and a scheduled rollout will need to happen for prod. However, the improved retrieval on French and Italian works is worth it.

The Sphinx config is LSDB-Docker has already been updated.