### PR TITLE
Bug Fix: XML Results Download

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2143,7 +2143,7 @@
               $subnode = $xml_data->addChild($key);
               array_to_xml($value, $subnode, $key);
           } else {
-              $xml_data->addChild("$key",htmlspecialchars("$value"));
+              $xml_data->addChild("$key",htmlspecialchars(utf8_for_xml("$value")));
           }
        }
      }
@@ -2156,6 +2156,17 @@
     header('Content-type: text/xml');
     echo $xml;
   }
+
+/**
+ * Removes unsupported UTF8 chars from string
+ *
+ * @param string $string String that needs to be prepared for XML conversion.
+ *
+ * @return string
+ */
+function utf8_for_xml($string) {
+  return preg_replace ('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $string);
+}
 
 
   /**
@@ -2191,7 +2202,7 @@
               $subnode = $xml_data->addChild($key);
               array_to_xml($value, $subnode, $key);
           } else {
-              $xml_data->addChild("$key",htmlspecialchars("$value"));
+              $xml_data->addChild("$key",htmlspecialchars(utf8_for_xml("$value")));
           }
        }
      }


### PR DESCRIPTION
Fixes a malformed XML file error triggered by invalid characters in Events.Phase1 values in batch XML file downloads.

Steps to reproduce the current error:
1. Search for Moliere in the Author field.
2. Do an XML batch download of results.