### PR TITLE
Adds Sphinx Results Pages to robots.txt, Adjusts README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ If you would like to deploy the legacy version of the London Stage Database,
 which has an alternative search feature that does not require Sphinx to be installed,
 a [archived release bundled with installation instructions](https://github.com/LondonStageDB/website/releases/tag/v2.1) is available for download.
 
-As [legacy search was deprecated for performance and security reasons]
-(https://blogs.uoregon.edu/londonstage/2025/05/07/legacy/) we only
+As [legacy search was deprecated for performance and security reasons](https://blogs.uoregon.edu/londonstage/2025/05/07/legacy/) we only
 recommend this option for users who want to precisely replicate older search behavior.
 
 ## Code Structure

--- a/robots.txt
+++ b/robots.txt
@@ -3,6 +3,7 @@ Crawl-Delay: 120
 
 User-agent: *
 Disallow: /results.php
+Disallow: /sphinx-results.php
 Disallow: /get_all_csv.php
 Disallow: /get_all_json.php
 Disallow: /get_all_xml.php
@@ -12,3 +13,4 @@ Disallow: /get_all_sphinx_xml.php
 Disallow: /get_csv.php
 Disallow: /get_json.php
 Disallow: /get_xml.php
+Disallow: /get_tcp.php


### PR DESCRIPTION
A few superficial tweaks before the Zenodo release.

- Adds `sphinx-results.php` and `get_tcp.php` to robots.txt, though admittedly crawlers don't seem to respect robots.txt anymore
- Corrects a typo in README