### PR TITLE
Adjustment to tabindex

### DIFF
--- a/search.php
+++ b/search.php
@@ -115,7 +115,7 @@
             </div>
             <div class="form-group field-author inline-label">
               <label for="author" class="fb-select-label">Author</label>
-              <span data-tooltip class="top l-tooltip" tabindex="2" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
               <input type="text" class="author" name="author" id="author" value="<?php getSticky(1, 'author'); ?>" onKeyPress="checkEnter(event)">
             </div>
           </div>
@@ -148,7 +148,7 @@
           <div class="small-12 medium-8 large-6 cell form-section">
             <div class="form-group field-actor inline-label">
               <label for="actor" class="fb-text-label">Actor</label>
-              <span data-tooltip class="top l-tooltip" tabindex="2" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
               <span class="cast-switch">
                 <label for="actSwitch" class="show-for-sr">Select 'AND' or 'OR' search on multiple actors.</label>
                 <select name="actSwitch" id="actSwitch" title="Select 'AND' or 'OR' search on multiple actors." disabled="disabled">
@@ -187,7 +187,7 @@
           <div class="small-12 medium-8 large-6 cell form-section">
             <div class="form-group field-keyword inline-label">
               <label for="keyword" class="fb-text-label">Keyword </label>
-              <span data-tooltip class="top l-tooltip" tabindex="2" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
               <input type="text" class="keyword" name="keyword" id="keyword" onKeyPress="checkEnter(event)">
             </div>
           </div>

--- a/search.php
+++ b/search.php
@@ -115,7 +115,7 @@
             </div>
             <div class="form-group field-author inline-label">
               <label for="author" class="fb-select-label">Author</label>
-              <span data-tooltip class="top l-tooltip" tabindex="0" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="author-tooltip" aria-label="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations." title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
               <input type="text" class="author" name="author" id="author" value="<?php getSticky(1, 'author'); ?>" onKeyPress="checkEnter(event)">
             </div>
           </div>
@@ -148,7 +148,7 @@
           <div class="small-12 medium-8 large-6 cell form-section">
             <div class="form-group field-actor inline-label">
               <label for="actor" class="fb-text-label">Actor</label>
-              <span data-tooltip class="top l-tooltip" tabindex="0" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="actor-tooltip" aria-label="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
               <span class="cast-switch">
                 <label for="actSwitch" class="show-for-sr">Select 'AND' or 'OR' search on multiple actors.</label>
                 <select name="actSwitch" id="actSwitch" title="Select 'AND' or 'OR' search on multiple actors." disabled="disabled">
@@ -187,7 +187,7 @@
           <div class="small-12 medium-8 large-6 cell form-section">
             <div class="form-group field-keyword inline-label">
               <label for="keyword" class="fb-text-label">Keyword </label>
-              <span data-tooltip class="top l-tooltip" tabindex="0" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
+              <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="keyword-tooltip" aria-label="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names." title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
               <input type="text" class="keyword" name="keyword" id="keyword" onKeyPress="checkEnter(event)">
             </div>
           </div>

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -187,7 +187,7 @@
                   </div>
                   <div class="form-group field-author inline-label">
                     <label for="author" class="fb-select-label">Author</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="0" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="author-tooltip" aria-label="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations." title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
                     <input type="text" class="author" name="author" id="author" value="<?php getSticky(1, 'author'); ?>" onKeyPress="checkEnter(event)">
                   </div>
                 </div>
@@ -222,7 +222,7 @@
                 <div class="small-12 cell">
                   <div class="form-group field-actor inline-label">
                     <label for="actor" class="fb-text-label">Actor</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="0" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="actor-tooltip" aria-label="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
                     <span class="cast-switch">
                       <label for="actSwitch" class="show-for-sr">Select 'AND' or 'OR' search on multiple actors.</label>
                       <select name="actSwitch" id="actSwitch" title="Select 'AND' or 'OR' search on multiple actors." <?php echo (isset($_GET['actor']) && count(array_filter($_GET['actor'], 'strlen')) > 1) ? '' : 'disabled="disabled"'; ?>>
@@ -283,7 +283,7 @@
                 <div class="small-12 cell">
                   <div class="form-group field-keyword inline-label">
                     <label for="keyword" class="fb-text-label">Keyword</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="0" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" role="tooltip" id="keyword-tooltip" aria-label="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names." title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
                     <input type="text" class="keyword" name="keyword" id="keyword" value="<?php getSticky(1, 'keyword'); ?>" onKeyPress="checkEnter(event)">
                   </div>
                 </div>

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -187,7 +187,7 @@
                   </div>
                   <div class="form-group field-author inline-label">
                     <label for="author" class="fb-select-label">Author</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="2" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" title="Searches not only for performances of plays known to be by this author, but also performances of associated titles, including adaptations.">?</span>
                     <input type="text" class="author" name="author" id="author" value="<?php getSticky(1, 'author'); ?>" onKeyPress="checkEnter(event)">
                   </div>
                 </div>
@@ -222,7 +222,7 @@
                 <div class="small-12 cell">
                   <div class="form-group field-actor inline-label">
                     <label for="actor" class="fb-text-label">Actor</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="2" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" title="We recommend searching by last name (for example, instead of 'Dorothy Jordan,' search 'Jordan' to return instances where she is listed as 'Mrs Jordan')">?</span>
                     <span class="cast-switch">
                       <label for="actSwitch" class="show-for-sr">Select 'AND' or 'OR' search on multiple actors.</label>
                       <select name="actSwitch" id="actSwitch" title="Select 'AND' or 'OR' search on multiple actors." <?php echo (isset($_GET['actor']) && count(array_filter($_GET['actor'], 'strlen')) > 1) ? '' : 'disabled="disabled"'; ?>>
@@ -283,7 +283,7 @@
                 <div class="small-12 cell">
                   <div class="form-group field-keyword inline-label">
                     <label for="keyword" class="fb-text-label">Keyword</label>
-                    <span data-tooltip class="top l-tooltip" tabindex="2" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
+                    <span data-tooltip class="top l-tooltip" tabindex="0" title="Keyword searches event comments, performance titles, performance comments, roles, actors, and author names.">?</span>
                     <input type="text" class="keyword" name="keyword" id="keyword" value="<?php getSticky(1, 'keyword'); ?>" onKeyPress="checkEnter(event)">
                   </div>
                 </div>


### PR DESCRIPTION
Adjusted tabindex values regarding [A11y Report #90 ](https://github.com/LondonStageDB/website/issues/90) following the guidelines on [testingbot ](https://testingbot.com/support/accessibility/web/rules/tabindex#what-is-being-tested) about "tabindex>0". 

Updated "tab index = 2" to "tab index = 0".