### PR TITLE
Accessibility HTML Overhaul

### DIFF
--- a/about-data.php
+++ b/about-data.php
@@ -18,8 +18,10 @@
                  data-sticky-container>
                 <div data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
-                        <li><a href="#Challenges">Archival Challenges</a></li>
-                        <li><a href="#Ambiguity">Interacting with Ambiguity</a></li>
+                        <aside>
+                            <li><a href="#Challenges">Archival Challenges</a></li>
+                            <li><a href="#Ambiguity">Interacting with Ambiguity</a></li>
+                        </aside>
                     </ul>
                 </div>
             </nav>

--- a/about-data.php
+++ b/about-data.php
@@ -13,15 +13,13 @@
         <div class="small-12 page-heading">
             <h1>About the Data</h1>
         </div>
-        <div class="small-12 medium-4 large-3 about-data-nav" id="about-dataNav">
+        <aside class="small-12 medium-4 large-3 about-data-nav" id="about-dataNav">
             <nav class="show-for-small-only about-data-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav"
                  data-sticky-container>
                 <div data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
-                        <aside>
                             <li><a href="#Challenges">Archival Challenges</a></li>
                             <li><a href="#Ambiguity">Interacting with Ambiguity</a></li>
-                        </aside>
                     </ul>
                 </div>
             </nav>
@@ -34,7 +32,7 @@
                     </ul>
                 </div>
             </nav>
-        </div>
+</aside>
         <div id="top" class="small-12 medium-8 large-9 about-data-content">
             <div class="grid-x about-data-section">
                 <div class="small-12">

--- a/about-data.php
+++ b/about-data.php
@@ -32,7 +32,7 @@
                     </ul>
                 </div>
             </nav>
-</aside>
+        </aside>
         <div id="top" class="small-12 medium-8 large-9 about-data-content">
             <div class="grid-x about-data-section">
                 <div class="small-12">

--- a/about-data.php
+++ b/about-data.php
@@ -8,13 +8,13 @@
 
 <body id="about-data">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x about-data-wrap">
         <div class="small-12 page-heading">
             <h1>About the Data</h1>
         </div>
         <div class="small-12 medium-4 large-3 about-data-nav" id="about-dataNav">
-            <nav class="show-for-small-only about-data-mobile-nav sticky-container" id="mobileNav"
+            <nav class="show-for-small-only about-data-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav"
                  data-sticky-container>
                 <div data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
@@ -23,7 +23,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container about-data-nav-sticky show-for-medium" data-sticky-container>
+            <nav class="sticky-container about-data-nav-sticky show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div data-sticky data-anchor="about-dataNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>
@@ -140,7 +140,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/about.php
+++ b/about.php
@@ -24,7 +24,7 @@
                 </div>
             </nav>
 
-            <nav class="sticky-container show-for-medium" data-sticky-container>
+            <nav class="sticky-container show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div data-sticky data-anchor="aboutNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/about.php
+++ b/about.php
@@ -9,7 +9,7 @@
 <body id="about">
 <?php include_once('common/nav.php'); ?>
 
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x">
         <div class="small-12 page-heading">
             <h1>About</h1>
@@ -149,7 +149,7 @@
 
         </div>
     </div>
-</div>
+</main>
 
 <?php include_once('common/footer.php'); ?>
 </body>

--- a/about.php
+++ b/about.php
@@ -15,7 +15,7 @@
             <h1>About</h1>
         </div>
         <div class="small-12 medium-4 large-3 about-nav" id="aboutNav">
-            <nav class="show-for-small-only about-mobile-nav sticky-container" id="mobileNav" data-sticky-container>
+            <nav class="show-for-small-only about-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav" data-sticky-container>
                 <div data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
                         <li><a href="#Overview">About</a></li>

--- a/authors.php
+++ b/authors.php
@@ -8,7 +8,7 @@
 
 <body id="authors">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x authors-wrap">
         <div class="small-12 page-heading">
             <h1>Authors</h1>
@@ -62,7 +62,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/authors.php
+++ b/authors.php
@@ -16,7 +16,7 @@
         <div method="post" class="small-12 medium-11 large-9 cell grid-x authors-form">
             <div class="grid-x guide-section">
                 <div id="Authors" class="small-12" data-magellan-target="Authors">
-                    <p><img alt=""
+                    <p><img alt="Title page of Nahum Tate's adaptation of King Lear, 1736"
                             style="float:right;padding-left:25px;padding-bottom:25px;"
                             src="/images/lear-title-page.jpg">
                         Today we think about authorship a bit differently than people did in the long eighteenth

--- a/cast-list.php
+++ b/cast-list.php
@@ -21,7 +21,7 @@
                 consistent over the course of a season, it is reproduced in full the first time it appears with that
                 cast, and subsequent performances of the same play by the same company record the cast following the
                 syntax "As [date], but [substitutions, if any]." </p>
-            <p><img alt=""
+            <p><img alt="Ladder system Diagram for The Busy Body"
                     style="float:right;"
                     src="/images/cast-list-ladder.png"><br/><br/>So, for
                 example, a performance of <i>The Busy

--- a/cast-list.php
+++ b/cast-list.php
@@ -8,7 +8,7 @@
 
 <body id="cast-list">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x cast-list-wrap">
         <div class="small-12 page-heading">
             <h1>Cast Lists</h1>
@@ -59,7 +59,7 @@
             </p>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/citation.php
+++ b/citation.php
@@ -70,20 +70,18 @@
                             through
                             Zenodo:<br>
                             <ul>
-                                <ul>
-                                    <li><a href="https://doi.org/10.5281/zenodo.7328444"><img
-                                                    src="https://zenodo.org/badge/140609672.svg" alt="DOI"></a> Data
-                                        v1.0
-                                    </li>
-                                    <li><a href="https://doi.org/10.5281/zenodo.7328442"><img
-                                                    src="https://zenodo.org/badge/140609563.svg" alt="DOI"></a>
-                                        Database Code v1.0
-                                    </li>
-                                    <li><a href="https://doi.org/10.5281/zenodo.7328435"><img
-                                                    src="https://zenodo.org/badge/140609156.svg" alt="DOI"></a>
-                                        Website v2.1
-                                    </li>
-                                </ul>
+                                <li><a href="https://doi.org/10.5281/zenodo.7328444"><img
+                                                src="https://zenodo.org/badge/140609672.svg" alt="DOI"></a> Data
+                                    v1.0
+                                </li>
+                                <li><a href="https://doi.org/10.5281/zenodo.7328442"><img
+                                                src="https://zenodo.org/badge/140609563.svg" alt="DOI"></a>
+                                    Database Code v1.0
+                                </li>
+                                <li><a href="https://doi.org/10.5281/zenodo.7328435"><img
+                                                src="https://zenodo.org/badge/140609156.svg" alt="DOI"></a>
+                                    Website v2.1
+                                </li>
                             </ul>
                         </li>
                         <li><b>Open access:</b> Consistent with the <a href="https://www.neh.gov/publicaccess"

--- a/citation.php
+++ b/citation.php
@@ -8,7 +8,7 @@
 
 <body id="citation">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x">
         <div class="small-12 page-heading">
             <h1>Citation and Sharing</h1>
@@ -181,7 +181,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 
 <?php include_once('common/footer.php'); ?>
 </body>

--- a/citation.php
+++ b/citation.php
@@ -14,7 +14,7 @@
             <h1>Citation and Sharing</h1>
         </div>
         <div class="small-12 medium-4 large-3 citation-nav" id="citationNav">
-            <nav class="show-for-small-only citation-mobile-nav sticky-container" id="mobileNav" data-sticky-container>
+            <nav class="show-for-small-only citation-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav" data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
                         <li><a href="#OpenResearch">Open Research</a></li>
@@ -23,7 +23,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container show-for-medium" data-sticky-container>
+            <nav class="sticky-container show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div class data-sticky data-anchor="citationNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/common/nav.php
+++ b/common/nav.php
@@ -1,7 +1,7 @@
 <div class="header">
     <nav>
         <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
-            <button class="menu-icon" type="button" data-toggle="example-menu"></button>
+            <button class="menu-icon" type="button" data-toggle="example-menu" aria-label="Open navigation menu"></button>
             <div class="title-bar-title">Menu</div>
         </div>
         <div class="top-bar" id="example-menu">

--- a/common/nav.php
+++ b/common/nav.php
@@ -1,45 +1,40 @@
 <div class="header">
-    <nav aria-label="London Stage Database">
+    <nav>
         <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
             <button class="menu-icon" type="button" data-toggle="example-menu" aria-label="Open navigation menu"></button>
             <div class="title-bar-title">Menu</div>
         </div>
-        <div class="top-bar" role="banner">
+        <div class="top-bar" id="example-menu">
             <div class="top-bar-left">
-                <a role="link" href="/" class="menu-text">London Stage Database</a>
+                <a href="/" class="menu-text">London Stage Database</a>
             </div>
             <div class="top-bar-right">
-                <ul role="menu" class="dropdown menu" data-dropdown-menu>
-                    <li role="none">
-                        <a role="menuitem" href="/">Home</a>
-                    </li>
-                    <li role="none">
-                        <a role="menuitem" href="/search.php">Advanced Search</a>
-                    </li>
-                    <li role="none">
-                        <a role="menuitem" href="/data.php">Full Data Sets</a></li>
-                    <li role="none">
-                        <a role="menuitem" href="/guide.php">User Guide</a>
-                        <ul role="menu" class="menu vertical">
-                            <li role="none"><a role="menuitem" href="/about-data.php">About the Data</a></li>
-                            <li role="none"><a role="menuitem" href="/glossary.php">Glossary</a></li>
-                            <li role="none"><a role="menuitem" href="/cast-list.php">Cast Lists</a></li>
-                            <li role="none"><a role="menuitem" href="/authors.php">Authors</a></li>
-                            <li role="none"><a role="menuitem" href="/dates.php">Dates</a></li>
-                            <li role="none"><a role="menuitem" href="/tips.php">Search Tips</a></li>
+                <ul class="dropdown menu" data-dropdown-menu>
+                    <li><a href="/">Home</a></li>
+                    <li><a href="/search.php">Advanced Search</a></li>
+                    <li><a href="/data.php">Full Data Sets</a></li>
+                    <li>
+                        <a href="/guide.php">User Guide</a>
+                        <ul class="menu vertical">
+                            <li><a href="/about-data.php">About the Data</a></li>
+                            <li><a href="/glossary.php">Glossary</a></li>
+                            <li><a href="/cast-list.php">Cast Lists</a></li>
+                            <li><a href="/authors.php">Authors</a></li>
+                            <li><a href="/dates.php">Dates</a></li>
+                            <li><a href="/tips.php">Search Tips</a></li>
                         </ul>
                     </li>
                     <li>
                         <a href="/about.php">About</a>
-                        <ul role="menu" class="menu vertical">
-                            <li role="none"><a role="menuitem" href="/history.php">History</a></li>
-                            <li role="none"><a role="menuitem" href="/team.php">Team</a></li>
-                            <li role="none"><a role="menuitem" href="/citation.php">Citation and Sharing</a></li>
-                            <li role="none"><a role="menuitem" href="/media-coverage.php">Media Coverage</a></li>
+                        <ul class="menu vertical">
+                            <li><a href="/history.php">History</a></li>
+                            <li><a href="/team.php">Team</a></li>
+                            <li><a href="/citation.php">Citation and Sharing</a></li>
+                            <li><a href="/media-coverage.php">Media Coverage</a></li>
                         </ul>
                     </li>
-                    <li role="none"><a role="menuitem" href="/contact.php">Contact</a></li>
-                    <li role="none"><a role="menuitem" href="/news.php">News</a></li>
+                    <li><a href="/contact.php">Contact</a></li>
+                    <li><a href="/news.php">News</a></li>
                 </ul>
             </div>
 

--- a/common/nav.php
+++ b/common/nav.php
@@ -1,40 +1,45 @@
 <div class="header">
-    <nav>
+    <nav aria-label="London Stage Database">
         <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
             <button class="menu-icon" type="button" data-toggle="example-menu" aria-label="Open navigation menu"></button>
             <div class="title-bar-title">Menu</div>
         </div>
-        <div class="top-bar" id="example-menu">
+        <div class="top-bar" role="banner">
             <div class="top-bar-left">
-                <a href="/" class="menu-text">London Stage Database</a>
+                <a role="link" href="/" class="menu-text">London Stage Database</a>
             </div>
             <div class="top-bar-right">
-                <ul class="dropdown menu" data-dropdown-menu>
-                    <li><a href="/">Home</a></li>
-                    <li><a href="/search.php">Advanced Search</a></li>
-                    <li><a href="/data.php">Full Data Sets</a></li>
-                    <li>
-                        <a href="/guide.php">User Guide</a>
-                        <ul class="menu vertical">
-                            <li><a href="/about-data.php">About the Data</a></li>
-                            <li><a href="/glossary.php">Glossary</a></li>
-                            <li><a href="/cast-list.php">Cast Lists</a></li>
-                            <li><a href="/authors.php">Authors</a></li>
-                            <li><a href="/dates.php">Dates</a></li>
-                            <li><a href="/tips.php">Search Tips</a></li>
+                <ul role="menu" class="dropdown menu" data-dropdown-menu>
+                    <li role="none">
+                        <a role="menuitem" href="/">Home</a>
+                    </li>
+                    <li role="none">
+                        <a role="menuitem" href="/search.php">Advanced Search</a>
+                    </li>
+                    <li role="none">
+                        <a role="menuitem" href="/data.php">Full Data Sets</a></li>
+                    <li role="none">
+                        <a role="menuitem" href="/guide.php">User Guide</a>
+                        <ul role="menu" class="menu vertical">
+                            <li role="none"><a role="menuitem" href="/about-data.php">About the Data</a></li>
+                            <li role="none"><a role="menuitem" href="/glossary.php">Glossary</a></li>
+                            <li role="none"><a role="menuitem" href="/cast-list.php">Cast Lists</a></li>
+                            <li role="none"><a role="menuitem" href="/authors.php">Authors</a></li>
+                            <li role="none"><a role="menuitem" href="/dates.php">Dates</a></li>
+                            <li role="none"><a role="menuitem" href="/tips.php">Search Tips</a></li>
                         </ul>
                     </li>
                     <li>
                         <a href="/about.php">About</a>
-                        <ul class="menu vertical">
-                            <li><a href="/history.php">History</a></li>
-                            <li><a href="/team.php">Team</a></li>
-                            <li><a href="/citation.php">Citation and Sharing</a></li>
-                            <li><a href="/media-coverage.php">Media Coverage</a></li>
+                        <ul role="menu" class="menu vertical">
+                            <li role="none"><a role="menuitem" href="/history.php">History</a></li>
+                            <li role="none"><a role="menuitem" href="/team.php">Team</a></li>
+                            <li role="none"><a role="menuitem" href="/citation.php">Citation and Sharing</a></li>
+                            <li role="none"><a role="menuitem" href="/media-coverage.php">Media Coverage</a></li>
                         </ul>
                     </li>
-                    <li><a href="/contact.php">Contact</a></li>
-                    <li><a href="/news.php">News</a></li>
+                    <li role="none"><a role="menuitem" href="/contact.php">Contact</a></li>
+                    <li role="none"><a role="menuitem" href="/news.php">News</a></li>
                 </ul>
             </div>
 

--- a/contact.php
+++ b/contact.php
@@ -8,7 +8,7 @@
 
 <body id="contact">
   <?php include_once('common/nav.php'); ?>
-  <div id="main" class="main grid-container">
+  <main class="main grid-container">
     <div class="grid-x contact-wrap">
       <div class="small-12 page-heading">
         <h1>Contact Us</h1>
@@ -24,7 +24,7 @@
         </p>
       </div>
     </div>
-  </div>
+</main>
   <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/css/main.css
+++ b/css/main.css
@@ -1559,8 +1559,12 @@ body#home:after {
     padding: 0.3rem 0;
 }
 
-#event .perf-section, #event .perf-info {
+#event .perf-section {
     margin-top: 2.5rem;
+}
+
+#event .perf-info {
+    margin-top: 0.5rem;
 }
 
 #event .perf-section {
@@ -1594,6 +1598,27 @@ body#home:after {
     font-feature-settings: "smcp";
     -moz-font-feature-settings: "smcp";
     -webkit-font-feature-settings: "smcp";
+}
+#event .perf-type h2{
+    padding-left: 2.5rem;
+}
+
+#event .event-info h2{
+    padding: 0.2rem;
+    padding-bottom: 0.7rem;
+    font-size: 3rem;
+    font-weight: 500;
+    margin: 0;
+    display: inline-block;
+    position: relative;
+    font-family: 'aquilinetworegular';
+    color: #efefef;
+    color: #655446;
+/*  border-top: 1 px solid #7b7b7b;
+    border-bottom: 1 px solid #7b7b7b;*/
+    font-feature-settings: "smcp";
+    -moz-font-feature-settings: "smcp";
+    -webkit-font-feature-settings: "smcp";  
 }
 
 #event .perf-type h1:before {

--- a/css/main.css
+++ b/css/main.css
@@ -1572,7 +1572,7 @@ body#home:after {
     background: #ece7d9;
 }
 
-#event .perf-type h2 {
+#event .perf-type h1,h2 {
     padding: 0.7rem 0.3rem;
     font-size: 2.5rem;
     margin: 0;
@@ -1588,7 +1588,7 @@ body#home:after {
     -webkit-font-feature-settings: "smcp";
 }
 
-#event .perf-type h2:before {
+#event .perf-type h1:before,h2:before {
     content: '‰';
     line-height: 1px;
     height: 100%;
@@ -1598,7 +1598,7 @@ body#home:after {
     transform: scale(-1, -1);
 }
 
-#event .perf-type h2:after {
+#event .perf-type h1:after,h2:after {
     content: '‰';
     line-height: 1px;
     padding-left: 2rem;
@@ -1745,7 +1745,7 @@ body#home:after {
         padding: 2rem 0;
     }
 
-    #event .perf-type h2 {
+    #event .perf-type h1,h2 {
         font-size: 3.5rem;
     }
 
@@ -1769,7 +1769,7 @@ body#home:after {
 }
 
 @media only screen and (min-width: 1024px) {
-    #event .event-header-wrap h2 {
+    #event .event-header-wrap h1 {
         font-size: 4.5rem;
     }
 

--- a/css/main.css
+++ b/css/main.css
@@ -1572,7 +1572,7 @@ body#home:after {
     background: #ece7d9;
 }
 
-#event .perf-type h1,h2 {
+#event .perf-type h1, .perf-type h2 {
     padding: 0.7rem 0.3rem;
     font-size: 2.5rem;
     margin: 0;
@@ -1588,7 +1588,7 @@ body#home:after {
     -webkit-font-feature-settings: "smcp";
 }
 
-#event .perf-type h1:before,h2:before {
+#event .perf-type h1:before, .perf-type h2:before {
     content: '‰';
     line-height: 1px;
     height: 100%;
@@ -1598,7 +1598,7 @@ body#home:after {
     transform: scale(-1, -1);
 }
 
-#event .perf-type h1:after,h2:after {
+#event .perf-type h1:after, .perf-type h2:after {
     content: '‰';
     line-height: 1px;
     padding-left: 2rem;
@@ -1745,7 +1745,7 @@ body#home:after {
         padding: 2rem 0;
     }
 
-    #event .perf-type h1,h2 {
+    #event .perf-type h1, .perf-type h2 {
         font-size: 3.5rem;
     }
 

--- a/css/main.css
+++ b/css/main.css
@@ -1581,7 +1581,7 @@ body#home:after {
 }
 
 #event .perf-type h1, .perf-type h2 {
-    padding: 0.7rem 0.3rem;
+    padding: 0.7rem 0.3rem; 
     font-size: 2.5rem;
     margin: 0;
     display: inline-block;
@@ -1596,7 +1596,7 @@ body#home:after {
     -webkit-font-feature-settings: "smcp";
 }
 
-#event .perf-type h1:before, .perf-type h2:before {
+#event .perf-type h1:before {
     content: '‰';
     line-height: 1px;
     height: 100%;
@@ -1606,7 +1606,7 @@ body#home:after {
     transform: scale(-1, -1);
 }
 
-#event .perf-type h1:after, .perf-type h2:after {
+#event .perf-type h1:after {
     content: '‰';
     line-height: 1px;
     padding-left: 2rem;

--- a/css/main.css
+++ b/css/main.css
@@ -814,6 +814,14 @@ body#home:after {
     color: #5a4d3f;
 }
 
+#results .page-heading h1 {
+    text-align: center;
+    font-size: 3rem;
+    padding: 1rem 0;
+    font-family: 'aquilinetworegular';
+    padding-bottom: 2rem;
+}
+
 #results .date-type {
     font-size: 0.875rem;
     line-height: 1.2;

--- a/data.php
+++ b/data.php
@@ -8,7 +8,7 @@
 
 <body id="data">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x data-wrap">
         <div class="small-12 page-heading">
             <h1>Data Downloads</h1>
@@ -39,7 +39,7 @@
             <p>Data for individual events can be exported from the relevant Event page.</p>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/dates.php
+++ b/dates.php
@@ -8,7 +8,7 @@
 
 <body id="dates">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x dates-wrap">
         <div class="small-12 page-heading">
             <h1>Dates</h1>
@@ -33,7 +33,7 @@
             </p>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/event.php
+++ b/event.php
@@ -22,7 +22,7 @@
 
   <body id="event">
     <?php include_once('common/nav.php'); ?>
-    <div id="main" class="main grid-container">
+    <main class="main grid-container">
       <div class="grid-x event-section">
         <div class="cell small-12 event-header-wrap">
           <?php if ($referer !== '') : ?>
@@ -83,7 +83,7 @@
             <li class="book-pdf2 responsive-embed2">
               <div class="responsive-embed">
               <?php if ($event['BookPDF'] && $event['BookPDF'] !== '') : ?>
-              <object data="https://londonstage.blob.core.windows.net/lsdb-files/pdfs/<?php echo $event['BookPDF']; ?>" type="application/pdf" height="725px" width="532px">
+              <object aria-label="BookPDF" data="https://londonstage.blob.core.windows.net/lsdb-files/pdfs/<?php echo $event['BookPDF']; ?>" type="application/pdf" height="725px" width="532px">
                 <p>Your web browser doesn't have a PDF plugin. Instead, <a href="https://londonstage.blob.core.windows.net/lsdb-files/pdfs/<?php echo $event['BookPDF']; ?>">click here to download the PDF file</a></p>
               </object>
               <?php else : ?>
@@ -287,7 +287,7 @@
           <span>MLA: </span><span id="citeMla"></span>
         </div>
       </div>
-    </div>
+    </main>
     <?php include_once('common/footer.php'); ?>
     <script src="/js/vendor/jquery.flexslider2-7-2-min.js"></script>
     <script>

--- a/event.php
+++ b/event.php
@@ -30,7 +30,7 @@
           <?php endif; ?>
           <div class="grid-x perf-type-wrap">
             <div class="cell small-12 text-center perf-type">
-              <h2 title="<?php echo formatDate($event['EventDate'], true); ?>"><?php echo formatDate($event['EventDate']); ?></h2></div>
+              <h1 title="<?php echo formatDate($event['EventDate'], true); ?>"><?php echo formatDate($event['EventDate']); ?></h1></div>
           </div>
         </div>
         <div class="cell small-12 medium-6 event-info">

--- a/event.php
+++ b/event.php
@@ -49,7 +49,7 @@
           </div>
           <div class="event-btns grid-x">
             <div class="work-nav small-12 medium-6 large-6">
-              <h2>Performance List</h2>
+              <h3>Performance List</h3>
               <ul class="no-bullet">
                 <?php foreach ($event['Performances'] as $perf) : ?>
                 <li>

--- a/event.php
+++ b/event.php
@@ -70,7 +70,7 @@
         </div>
         <div class="cell small-12 medium-6 phases-wrap">
           <div id="carousel" class="flexslider">
-            <span>Data Phases</span>
+            <span><h2>Data Phases</h2></span>
             <ul class="slides">
               <li><a href="#">PDF</a></li>
               <li><a href="#">Original</a></li>

--- a/event.php
+++ b/event.php
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="cell small-12 medium-6 event-info">
-          <span>Event Information</span>
+          <h2>Event Information</h2>
           <div class="event-theatre"><span class="info-heading">Theatre:</span>
             <?php echo getTheatreName($event['TheatreId']); ?>
           </div>
@@ -161,7 +161,7 @@
         <?php foreach ($event['Performances'] as $perf) : ?>
         <div class="cell small-12 perf">
           <div class="grid-x perf-type-wrap">
-            <div class="cell small-12 text-center perf-type" id="<?php echo $perf['PerformanceId'] ?>">
+            <div class="cell small-12 text-left perf-type" id="<?php echo $perf['PerformanceId'] ?>">
               <h2><?php echo getPType($perf['PType']) ?></h2></div>
           </div>
           <div class="grid-x perf-info-wrap">

--- a/event.php
+++ b/event.php
@@ -279,7 +279,7 @@
         <?php endforeach; ?>
       </div>
       <div class="cite-wrap hide">
-        <h4>Cite this page</h4>
+        <aside aria-label="citation">Cite this page</aside>
         <div class="cite-chicago-wrap">
           <span>Chicago: </span><span id="citeChicago"></span>
         </div>

--- a/event.php
+++ b/event.php
@@ -49,7 +49,7 @@
           </div>
           <div class="event-btns grid-x">
             <div class="work-nav small-12 medium-6 large-6">
-              <h3>Performance List</h3>
+              <h2>Performance List</h2>
               <ul class="no-bullet">
                 <?php foreach ($event['Performances'] as $perf) : ?>
                 <li>
@@ -92,7 +92,7 @@
               </div>
             </li>
             <li id="orig" class="phase2 p-orig2">
-              <div class="phase-content">
+              <div class="phase-content" tabindex="0" aria-label="Original Data" role="region">
                 <h3>Original Data</h3>
                 <p class="orig-source">Source:
                   <?php if ($event['Hathi'] !== '') echo 'OCR from HathiTrust PDFs'; else echo 'London Stage Information Bank' ?>
@@ -103,7 +103,7 @@
               </div>
             </li>
             <li id="fixed" class="phase2 p-fixed2">
-              <div class="phase-content">
+              <div class="phase-content" tabindex="0" aria-label="Cleaned Data" role="region">
                 <h3>Cleaned Data</h3>
                 <div class="phase-data">
                   <?php echo htmlentities($event['Phase2']); ?>
@@ -111,7 +111,7 @@
               </div>
             </li>
             <li id="phase3" class="phase2 p-final2">
-              <div class="phase-content">
+              <div class="phase-content" tabindex="0" aria-label="Parsed Data" role="region">
                 <h3>Parsed Data</h3>
                 <div class="phase-data">
                   <?php

--- a/glossary.php
+++ b/glossary.php
@@ -14,7 +14,7 @@
             <h1>Glossary</h1>
         </div>
         <aside class="small-12 medium-4 large-3 glossary-nav" id="glossaryNav">
-            <nav class="show-for-small-only glossary-mobile-nav sticky-container" id="mobileNav"
+            <nav class="show-for-small-only glossary-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav"
                  data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
@@ -24,7 +24,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container glossary-nav-sticky show-for-medium" data-sticky-container>
+            <nav class="sticky-container glossary-nav-sticky show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div data-sticky data-anchor="glossaryNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/glossary.php
+++ b/glossary.php
@@ -8,12 +8,12 @@
 
 <body id="glossary">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x glossary-wrap">
         <div class="small-12 page-heading">
             <h1>Glossary</h1>
         </div>
-        <div class="small-12 medium-4 large-3 glossary-nav" id="glossaryNav">
+        <aside class="small-12 medium-4 large-3 glossary-nav" id="glossaryNav">
             <nav class="show-for-small-only glossary-mobile-nav sticky-container" id="mobileNav"
                  data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
@@ -34,7 +34,7 @@
                     </ul>
                 </div>
             </nav>
-        </div>
+        </aside>
         <div id="top" class="small-12 medium-8 large-9 glossary-content">
             <div class="grid-x glossary-section">
                 <div class="small-12">
@@ -142,7 +142,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 </div>
 <?php include_once('common/footer.php'); ?>
 </body>

--- a/guide.php
+++ b/guide.php
@@ -8,7 +8,7 @@
 
 <body id="guide">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x guide-wrap">
         <div class="small-12 page-heading">
             <h1>User Guide</h1>
@@ -43,6 +43,6 @@
             </ul>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>

--- a/history.php
+++ b/history.php
@@ -14,7 +14,7 @@
             <h1>History</h1>
         </div>
         <div class="small-12 medium-4 large-3 history-nav" id="historyNav">
-            <nav class="show-for-small-only history-mobile-nav sticky-container" id="mobileNav" data-sticky-container>
+            <nav class="show-for-small-only history-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav" data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
                         <li><a href="#curation">1960-8: Curation</a></li>
@@ -25,7 +25,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container show-for-medium" data-sticky-container>
+            <nav class="sticky-container show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div class data-sticky data-anchor="historyNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/history.php
+++ b/history.php
@@ -41,7 +41,7 @@
         <div id="top" class="small-12 medium-8 large-9 history-content">
             <div class="grid-x history-section">
                 <div id="curation" class="small-12" data-magellan-target="curation">
-                    <img alt="image of title page of The London Stage reference books"
+                    <img alt="title page of The London Stage reference books"
                          style="float:right;padding-left:25px;width:225px;height:306.31px;"
                          src="images/timeline-image3.jpeg">
                     <h2>1960-8: Curation</h2>
@@ -61,7 +61,7 @@
             <div class="grid-x history-section">
                 <div id="digitization" class="small-12" data-magellan-target="digitization">
                     <hr/>
-                    <img alt="newspaper photograph of editors in a classroom at work on the London State Information Bank. Caption states: Photos by Nancy. Editors MARC WEINBERGER, Ben Schneider, Joe Jacobs, can be found in MH-427 at almost any hour of the day or night."
+                    <img alt="newspaper photograph of editors Marc Weinberger, Ben Schneider, Joe Jacobs, and Cathy Boggs gathered around a computer terminal"
                          style="float:left;padding-right:25px;width:275px;height:225px;"
                          src="images/timeline-image2.jpeg">
                     <h2>1970-83: Digitization</h2>
@@ -81,7 +81,7 @@
             <div class="grid-x history-section">
                 <div id="recovery" class="small-12" data-magellan-target="recovery">
                     <hr/>
-                    <img alt="Headline LU to house The London Stage data bank with accompanying photograph, March 1971, page 8."
+                    <img alt="Lawrence Alumnus for March 1971. Headline reads: 'LU to house The London Stage data bank'"
                          style="float:right;padding-left:25px;width:300px;height:233.5px;"
                          src="images/timeline-image1.jpeg">
                     <h2>2013-17: Recovery</h2>
@@ -99,7 +99,7 @@
             <div class="grid-x history-section">
                 <div id="remediation" class="small-12" data-magellan-target="remediation">
                     <hr/>
-                    <img alt="Headline LU to house The London Stage data bank with accompanying photograph, March 1971, page 8."
+                    <img alt="NEH Office of Digital Humanities: Award details for The London Stage Database"
                          style="float:left;padding-right:25px;width:225px;height:310px;"
                          src="images/lsdb-neh-2019.jpg">
                     <h2>2018-24: Remediation and Migration</h2>

--- a/history.php
+++ b/history.php
@@ -8,7 +8,7 @@
 
 <body id="history">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x">
         <div class="small-12 page-heading">
             <h1>History</h1>
@@ -146,7 +146,7 @@
 
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
 
 <body id="home" class="home-page">
   <?php include_once('common/nav.php'); ?>
-  <div id="main" class="main">
+  <main class="main">
     <div class="form-wrap">
       <h1>London Stage Database</h1>
       <form id="searchForm" class="search-form grid-x grid-margin-x" method="get" action="sphinx-results.php">
@@ -18,7 +18,7 @@
         <a href="search.php" class="adv-search">Advanced Search</a>
       </form>
     </div>
-  </div>
+</main>
 
   <?php include_once('common/footer.php'); ?>
 </body>

--- a/media-coverage.php
+++ b/media-coverage.php
@@ -8,7 +8,7 @@
 
 <body id="media-coverage">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x media-coverage-wrap">
         <div class="small-12 page-heading">
             <h1>Media Coverage</h1>
@@ -68,7 +68,7 @@
 
         </div>
     </div>
-</div>
+</main>
 
 <?php include_once('common/footer.php'); ?>
 </body>

--- a/news.php
+++ b/news.php
@@ -11,7 +11,7 @@
 
 <body id="contact">
   <?php include_once('common/nav.php'); ?>
-  <div id="main" class="main grid-container">
+  <main class="main grid-container">
     <div class="grid-x contact-wrap">
       <div class="small-12 page-heading">
         <h1>News</h1>
@@ -23,7 +23,7 @@
         ?>
       </div>
     </div>
-  </div>
+</main>
   <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/search.php
+++ b/search.php
@@ -11,7 +11,7 @@
 
 <body id="mainSearch">
   <?php include_once('common/nav.php'); ?>
-  <div id="main" class="main grid-container">
+  <main class="main grid-container">
     <h1>Advanced Search</h1>
     <form id="searchForm" class="form-accordion search-form grid-x grid-margin-x" method="get" action="sphinx-results.php">
       <input type="hidden" name="sortBy" value="relevance">
@@ -197,7 +197,7 @@
         <input type="submit" class="search-submit button" value="Search">
       </div>
     </form>
-  </div>
+  </main>
   <?php include_once('common/footer.php'); ?>
   <script src="https://code.jquery.com/ui/1.14.1/jquery-ui.js"></script>
   <script src="/js/search.js"></script>

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -62,7 +62,7 @@
 
 <body id="results">
   <?php include_once('common/nav.php'); ?>
-  <div id="main" class="main grid-container">
+  <main class="main grid-container">
     <div class="sql-query-wrap">
       <div class="toggle-query"><a id="toggle">Toggle Sphinx Query</a></div>
       <div class="sql-query">
@@ -462,9 +462,9 @@
           <?php } ?>
         </div>
       </div>
-  </div>
+    </div>
   </form>
-  </div>
+  </main>
   <?php include_once('common/footer.php'); ?>
   <script src="https://code.jquery.com/ui/1.14.1/jquery-ui.js"></script>
   <script src="/js/search.js"></script>

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -63,6 +63,9 @@
 <body id="results">
   <?php include_once('common/nav.php'); ?>
   <main class="main grid-container">
+    <div class="small-12 page-heading">
+      <h1>Search Results</h1>
+    </div>
     <div class="sql-query-wrap">
       <div class="toggle-query"><a id="toggle">Toggle Sphinx Query</a></div>
       <div class="sql-query">

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -347,7 +347,7 @@
                   <input type="submit" class="search-submit button" value="Update">
                 </div>
               </div>
-              <nav aria-label="Pagination" class="grid-x pag-wrap">
+              <nav aria-label="Upper Pagination" class="grid-x pag-wrap">
                 <?php echo $Paginator->createLinks( $links, 'pagination pagination-sm' ); ?>
               </nav>
             </div>
@@ -452,7 +452,7 @@
               <?php endfor; ?>
             </div>
           </div>
-          <nav aria-label="Pagination" class="grid-x pag-wrap">
+          <nav aria-label="Lower Pagination" class="grid-x pag-wrap">
             <?php echo $Paginator->createLinks( $links, 'pagination pagination-sm pag-bottom' ); ?>
           </nav>
           <?php } else { ?>

--- a/team.php
+++ b/team.php
@@ -14,7 +14,7 @@
             <h1>Meet the Team</h1>
         </div>
         <div class="small-12 medium-4 large-3 team-nav" id="teamNav">
-            <nav class="show-for-small-only team-mobile-nav sticky-container" id="mobileNav" data-sticky-container>
+            <nav class="show-for-small-only team-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav" data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
                         <li><a href="#PI">Principal Investigator</a></li>
@@ -27,7 +27,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container show-for-medium" data-sticky-container>
+            <nav class="sticky-container show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div class data-sticky data-anchor="teamNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/team.php
+++ b/team.php
@@ -8,7 +8,7 @@
 
 <body id="team">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x">
         <div class="small-12 page-heading">
             <h1>Meet the Team</h1>
@@ -495,7 +495,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 

--- a/tips.php
+++ b/tips.php
@@ -14,7 +14,7 @@
             <h1>Search Tips</h1>
         </div>
         <div class="small-12 medium-4 large-3 tips-nav" id="tipsNav">
-            <nav class="show-for-small-only tips-mobile-nav sticky-container" id="mobileNav" data-sticky-container>
+            <nav class="show-for-small-only tips-mobile-nav sticky-container" aria-label="mobile-nav" id="mobileNav" data-sticky-container>
                 <div class data-sticky data-anchor="mobileNav" data-sticky-on="small">
                     <ul class="menu" data-magellan>
                         <li><a href="#Search">Keyword Search</a>
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
             </nav>
-            <nav class="sticky-container tips-nav-sticky show-for-medium" data-sticky-container>
+            <nav class="sticky-container tips-nav-sticky show-for-medium" aria-label="nav-sticky" data-sticky-container>
                 <div data-sticky data-anchor="tipsNav" data-sticky-on="medium">
                     <h2>On This Page</h2>
                     <ul class="vertical menu" data-magellan>

--- a/tips.php
+++ b/tips.php
@@ -8,7 +8,7 @@
 
 <body id="tips">
 <?php include_once('common/nav.php'); ?>
-<div id="main" class="main grid-container">
+<main class="main grid-container">
     <div class="grid-x tips-wrap">
         <div class="small-12 page-heading">
             <h1>Search Tips</h1>
@@ -95,7 +95,7 @@
             </div>
         </div>
     </div>
-</div>
+</main>
 <?php include_once('common/footer.php'); ?>
 </body>
 


### PR DESCRIPTION
Updated the following files to comply with the Cypress Accessibility testing tool to close #90 

* about-data.php
* about.php
* authors.php
* cast-list.php
* citation.php
* common/nav.php
* contact/php
* data.php
* dates.php
* event.php
* glossary.php
* guide.php
* history.php
* index.php
* media-coverage.php
* news.php
* search.php
* sphinx-results.php
* tips.php


Adjusted the css in:

* css/main.css

The Passing Cypress Report:
[cypress-passing.html](https://github.com/user-attachments/files/25854318/cypress-passing.html)
