### PR TITLE
Prevents Internal Server Error Crashes from Malformed Actor/Role URLS

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -98,7 +98,7 @@
             }
             break;
           case 'actor':
-            if (!is_array($actor)) break;
+            $actor = filter_var($actor, FILTER_DEFAULT, FILTER_FORCE_ARRAY);
             $actor = array_filter($actor, 'strlen');
             if (count($actor) < 1) break;
             $actQry = (count($actor) > 1 && $actSwtch === "AND") ?
@@ -107,7 +107,7 @@
             array_push($eventIdQueries, $actQry);
             break;
           case 'role':
-            if (!is_array($role)) break;
+            $role = filter_var($role, FILTER_DEFAULT, FILTER_FORCE_ARRAY);
             $role = array_filter($role, 'strlen');
             if (count($role) < 1) break;
             $roleQry = (count($role) > 1 && $roleSwtch === "AND") ?

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -78,7 +78,6 @@
     if ($dateQuery !== '') {
       array_push($queries, $dateQuery);
     }
-
     // Add $queries entry for each value in $getters
     if (!empty($getters)) {
       foreach ($getters as $key => $value) {
@@ -99,6 +98,7 @@
             }
             break;
           case 'actor':
+            if (!is_array($actor)) break;
             $actor = array_filter($actor, 'strlen');
             if (count($actor) < 1) break;
             $actQry = (count($actor) > 1 && $actSwtch === "AND") ?
@@ -107,6 +107,7 @@
             array_push($eventIdQueries, $actQry);
             break;
           case 'role':
+            if (!is_array($role)) break;
             $role = array_filter($role, 'strlen');
             if (count($role) < 1) break;
             $roleQry = (count($role) > 1 && $roleSwtch === "AND") ?

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -27,6 +27,10 @@
   // Add the ranker OPTION statements for sphinx to be output in Toggle SQL.
   $sql       .= "\nOPTION " . $Paginator->getFieldWeights();
 
+  // Validate actor and role params
+  $_GET['actor'] = $ids = filter_input(INPUT_GET, 'actor', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
+  $_GET['role'] = $ids = filter_input(INPUT_GET, 'role', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
+
   // Cleaned, pipe delimited strings from 'actor' and 'role' arrays
   if (!empty($_GET['actor'])) {
     $getActors = array_map(function ($act) {

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -28,8 +28,8 @@
   $sql       .= "\nOPTION " . $Paginator->getFieldWeights();
 
   // Validate actor and role params
-  $_GET['actor'] = $ids = filter_input(INPUT_GET, 'actor', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
-  $_GET['role'] = $ids = filter_input(INPUT_GET, 'role', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
+  $_GET['actor'] = filter_input(INPUT_GET, 'actor', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
+  $_GET['role'] = filter_input(INPUT_GET, 'role', FILTER_DEFAULT, FILTER_FORCE_ARRAY);
 
   // Cleaned, pipe delimited strings from 'actor' and 'role' arrays
   if (!empty($_GET['actor'])) {


### PR DESCRIPTION
We've been experiencing an uptick in PHP errors triggered by invalid assignments to the role and actor parameters from (ugh) bot traffic. The menus on `search.php` create parameters assignments in the form `role[]=Role+Name`, but we've been spammed by bots with automatically generated URLs that use the form `role=Role+Name`. These crash the site with a 500 error.

**Known Bad URL Patterns**
```output
45.39.125.201 - - [14/May/2026:07:03:51 -0700] "GET /sphinx-results.php?role=Clerk HTTP/1.1" 500 -
82.24.245.192 - - [14/May/2026:07:03:51 -0700] "GET /sphinx-results.php?role=Giants HTTP/1.1" 500 -
82.21.226.189 - - [14/May/2026:07:03:54 -0700] "GET /sphinx-results.php?role=Aspin HTTP/1.1" 500 -
185.48.55.139 - - [14/May/2026:07:03:54 -0700] "GET /sphinx-results.php?role=Murtoch+Delany HTTP/1.1" 500 -
45.39.35.227 - - [14/May/2026:18:01:03 -0700] "GET /sphinx-results.php?role=2d+Gardener HTTP/1.1" 500 -
107.175.55.146 - - [14/May/2026:18:02:29 -0700] "GET /sphinx-results.php?role=Mr+Cockney HTTP/1.1" 500 -
154.6.115.171 - - [14/May/2026:18:02:34 -0700] "GET /sphinx-results.php?role=Romuald HTTP/1.1" 500 -
191.101.94.171 - - [14/May/2026:18:02:36 -0700] "GET /sphinx-results.php?role=Reinhard HTTP/1.1" 500 -
2.57.20.10 - - [14/May/2026:18:02:36 -0700] "GET /sphinx-results.php?role=Lazarra%27s+Servant HTTP/1.1" 500 -
204.217.160.139 - - [14/May/2026:18:02:37 -0700] "GET /sphinx-results.php?role=Lazarra HTTP/1.1" 500 -
31.58.16.204 - - [14/May/2026:18:02:37 -0700] "GET /sphinx-results.php?role=Mountaineer HTTP/1.1" 500 -
104.252.44.16 - - [15/May/2026:00:28:32 -0700] "GET /sphinx-results.php?role=Marzia HTTP/1.1" 500 -

```

**Example Error Messages**
```output
[15-May-2026 01:01:01 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:102
#0 /var/www/html/includes/functions.php(102): array_filter()
[15-May-2026 01:01:03 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
[15-May-2026 01:02:28 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:102
#0 /var/www/html/includes/functions.php(102): array_filter()
[15-May-2026 01:02:29 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
[15-May-2026 01:02:34 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
[15-May-2026 01:02:36 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
[15-May-2026 01:02:36 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
[15-May-2026 01:02:37 UTC] PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /var/www/html/includes/functions.php:110
#0 /var/www/html/includes/functions.php(110): array_filter()
```

This PR fixes this behavior by coercing all values passed to role and actor to arrays. It has been tested on Docker and is available for further testing on staging. 