### PR TITLE
Cloudflare turnstile implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /Data
 /includes/db.php
+/includes/turnstile_config.php
 *.swp
 /PDFs/NA
 /PDFs/node_modules

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ To prevent bots which do not respect robots.txt and protect DDOS attackig on dow
  - First, follow this guide to create your reCAPTCHA in Google Cloud platform: [reCAPTCHA v3 Guides](https://developers.google.com/recaptcha/docs/v3).
  - Then, provide site key and secret key in the `db.php` file.
 
+### (optional) Cloudflare Turnstile (search results protection)
+
+High-volume bot/scraper traffic against the search results page (`sphinx-results.php`)
+can exhaust database connections, because that endpoint opens DB connections and runs a
+Sphinx query on every request. To protect it, you can put a **Cloudflare Turnstile** gate
+in front of `sphinx-results.php`.
+
+When enabled, an unverified visitor is shown a one-time Turnstile challenge and the script
+exits *before* any database connection is opened; bots that cannot solve the challenge never
+reach the query. Once a visitor passes, a session flag lets all of their subsequent searches,
+pagination, and sorting through untouched.
+
+ - Create a Turnstile widget in the Cloudflare dashboard: [Turnstile Get Started](https://developers.cloudflare.com/turnstile/get-started/).
+ - In the `/includes` folder, create a file named `turnstile_config.php` with your keys:
+
+``` php
+<?php
+  define("TURNSTILE_SITE_KEY", "your-site-key");
+  define("TURNSTILE_SECRET_KEY", "your-secret-key");
+?>
+```
+
+If the keys are left empty (or the file is absent), the gate does nothing and the site
+behaves as before. Note: because search-engine crawlers cannot solve Turnstile, enabling
+this gate stops `sphinx-results.php` pages from being indexed.
+
 ### Create the `db.php` File
 
 In the `/includes` folder, create a file named `db.php`. Use the code below as a template for the file.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ searches, pagination, sorting, and downloads through untouched.
 
 ``` php
 <?php
-  define("TURNSTILE_SITE_KEY", "your-site-key");
-  define("TURNSTILE_SECRET_KEY", "your-secret-key");
+  define("TURNSTILE_SITE_KEY", "");     // Replace "" with your Cloudflare Turnstile site key in quotes.
+  define("TURNSTILE_SECRET_KEY", "");   // Replace "" with your Cloudflare Turnstile secret key in quotes.
 ```
 
 If the file is absent, or the keys are left empty, the gate does nothing and the site

--- a/README.md
+++ b/README.md
@@ -83,23 +83,18 @@ Now start serving requests.
 ```bash
 searchd --config /path/to/sphinx/conf/sphinx.conf
 ```
-### (optional) Google reCAPTCHA v3
+### (optional) Cloudflare Turnstile
 
-To prevent bots which do not respect robots.txt and protect DDOS attackig on downloading, you can set up **Google reCAPTCHA v3** for your site.
- - First, follow this guide to create your reCAPTCHA in Google Cloud platform: [reCAPTCHA v3 Guides](https://developers.google.com/recaptcha/docs/v3).
- - Then, provide site key and secret key in the `db.php` file.
-
-### (optional) Cloudflare Turnstile (search results protection)
-
-High-volume bot/scraper traffic against the search results page (`sphinx-results.php`)
-can exhaust database connections, because that endpoint opens DB connections and runs a
-Sphinx query on every request. To protect it, you can put a **Cloudflare Turnstile** gate
-in front of `sphinx-results.php`.
+High-volume bot/scraper traffic against the data-bearing endpoints (`sphinx-results.php`,
+`event.php`, `search.php`, and the CSV/JSON/XML download scripts) can exhaust database
+connections, because each of those endpoints opens DB connections and runs a query on every
+request. To protect them, you can put a **Cloudflare Turnstile** gate in front of every
+entry point that opens a DB connection.
 
 When enabled, an unverified visitor is shown a one-time Turnstile challenge and the script
-exits *before* any database connection is opened; bots that cannot solve the challenge never
-reach the query. Once a visitor passes, a session flag lets all of their subsequent searches,
-pagination, and sorting through untouched.
+exits *before* any database connection is opened; bots that cannot solve the challenge
+never reach the query. Once a visitor passes, a session flag lets all of their subsequent
+searches, pagination, sorting, and downloads through untouched.
 
  - Create a Turnstile widget in the Cloudflare dashboard: [Turnstile Get Started](https://developers.cloudflare.com/turnstile/get-started/).
  - In the `/includes` folder, create a file named `turnstile_config.php` with your keys:
@@ -108,12 +103,11 @@ pagination, and sorting through untouched.
 <?php
   define("TURNSTILE_SITE_KEY", "your-site-key");
   define("TURNSTILE_SECRET_KEY", "your-secret-key");
-?>
 ```
 
-If the keys are left empty (or the file is absent), the gate does nothing and the site
-behaves as before. Note: because search-engine crawlers cannot solve Turnstile, enabling
-this gate stops `sphinx-results.php` pages from being indexed.
+If the file is absent, or the keys are left empty, the gate does nothing and the site
+behaves as before. Note: because search-engine crawlers cannot solve Turnstile, enabling this gate stops
+the gated pages from being indexed by search engines.
 
 ### Create the `db.php` File
 
@@ -143,9 +137,6 @@ password, and database configuration details.
   define("SPHINX_PORT", "9306");
 
   $sphinx_conn = new mysqli(SPHINX_HOST, SPHINX_USER, SPHINX_PASS, SPHINX_NAME, SPHINX_PORT);
-
-  define("GOOGLE_RECAPTCHA_SITE_KEY", "");
-  define("GOOGLE_RECAPTCHA_SECRET_KEY", "");
 
 ?>
 ```
@@ -187,5 +178,15 @@ recommend this option for users who want to precisely replicate older search beh
 
 - /includes/db.php
         Database config file (Not included in repo. You will need to create your own - see above)
+
+
+- /includes/turnstile_gate.php
+        Cloudflare Turnstile gate. Included at the top of every entry point that
+        opens a DB connection; rejects unverified visitors before any connection
+        is opened. Reads its keys from turnstile_config.php.
+
+
+- /includes/turnstile_config.php
+        Cloudflare Turnstile keys (Not included in repo. You will need to create your own. Optional - see above)
 
 ```

--- a/event.php
+++ b/event.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
   $eventId = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);

--- a/get_all_sphinx_csv.php
+++ b/get_all_sphinx_csv.php
@@ -1,113 +1,23 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
-  // Check Google reCAPTCHA settings.
-  $recaptcha = FALSE;
-  if (defined("GOOGLE_RECAPTCHA_SITE_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SITE_KEY) &&
-      defined("GOOGLE_RECAPTCHA_SECRET_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SECRET_KEY)
-     ) {
-      $recaptcha = TRUE;
+  global $sphinx_conn;
+
+  // Use current $_GET variables to build the same query used on results page, minus the LIMIT
+  $sql  = buildSphinxQuery();
+  $sql .= ' LIMIT 99999 OPTION max_matches=99999';
+  $result = $sphinx_conn->query($sql);
+
+  $qResults = [];
+  while ($row = $result->fetch_assoc()) {
+    $qResults[] = $row;
   }
 
-  // If not enabled, download the file directly.
-  if (!$recaptcha) {
-    download();
-  }
+  // Only care about EventIds
+  $ids = array_column($qResults, 'eventid');
 
-  // If enabled, use it to detect human.
-  if ($recaptcha && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['recaptcha_token'])) {
-    // Build POST request:
-    $recaptcha_url = 'https://www.google.com/recaptcha/api/siteverify';
-    $recaptcha_secret = GOOGLE_RECAPTCHA_SECRET_KEY;
-    $recaptcha_response = $_POST['recaptcha_token'];
-
-    // Make and decode POST request:
-    $response = file_get_contents($recaptcha_url . '?secret=' . $recaptcha_secret . '&response=' . $recaptcha_response);
-    $responseData  = json_decode($response);
-
-    // Take action based on the score returned:
-    if ($responseData->success && $responseData->score >= 0.5) {
-      // Verified, start downloading
-      download();
-    }
-  }
-
-  function download() {
-    global $sphinx_conn;
-
-    $qResults = [];
-    $ids = [];
-
-    // Use current $_GET variables to build the same query used on results page, minus the LIMIT
-    $sql = buildSphinxQuery();
-    $sql .= ' LIMIT 99999 OPTION max_matches=99999';
-    $result = $sphinx_conn->query($sql);
-
-    while ($row = $result->fetch_assoc()) {
-      $qResults[] = $row;
-    }
-
-    // Only care about EventIds
-    $ids = array_column($qResults, 'eventid');
-
-    // Send IDs array to get all event info, returns CSV Doc
-    getResultsCSV($ids);
-
-    global $conn;
-    if (isset($conn) && $conn instanceof mysqli) { $conn->close(); }
-    if (isset($sphinx_conn) && $sphinx_conn instanceof mysqli) { $sphinx_conn->close(); }
-
-    die();
-  }
-
-?>
-<html>
-<head>
-<title>Download CSV</title>
-
-<script
-  src="https://www.google.com/recaptcha/api.js?render=<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>">
-</script>
-<script>
-  grecaptcha.ready(function() {
-    grecaptcha.execute("<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>", {action: 'download'}).then(function(token) {
-      // Send the token to your server
-      document.getElementById('recaptcha-token').value = token;
-    });
-  });
-</script>
-<style>
-  .backdrop {
-    position: fixed; /* Positions the backdrop relative to the viewport */
-    top: 0;
-    left: 0;
-    width: 100vw; /* Full viewport width */
-    height: 100vh; /* Full viewport height */
-    background-color: rgba(41, 33, 18); /* Semi-transparent black backdrop */
-    display: flex; /* Enables flexbox for centering */
-    justify-content: center; /* Horizontally centers content */
-    align-items: center; /* Vertically centers content */
-    z-index: 999; /* Ensures the backdrop is on top of other content */
-  }
-
-  .centered-button {
-    /* Basic button styling */
-    padding: 15px 30px;
-    font-size: 1.2em;
-    background-color: #6e2424;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-}
-</style>
-</head>
-<body class="backdrop">
-<form method="POST" id="recaptcha-form">
-  <input type="hidden" name="recaptcha_token" id="recaptcha-token"/>
-  <button type="submit" class="centered-button">I'm human.</button>
-</form>
-</body>
-</html>
+  // Send IDs array to get all event info, returns CSV Doc
+  getResultsCSV($ids);

--- a/get_all_sphinx_json.php
+++ b/get_all_sphinx_json.php
@@ -1,113 +1,23 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
-  // Check Google reCAPTCHA settings.
-  $recaptcha = FALSE;
-  if (defined("GOOGLE_RECAPTCHA_SITE_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SITE_KEY) &&
-      defined("GOOGLE_RECAPTCHA_SECRET_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SECRET_KEY)
-     ) {
-      $recaptcha = TRUE;
+  global $sphinx_conn;
+
+  // Use current $_GET variables to build the same query used on results page, minus the LIMIT
+  $sql  = buildSphinxQuery();
+  $sql .= ' LIMIT 99999 OPTION max_matches=99999';
+  $result = $sphinx_conn->query($sql);
+
+  $qResults = [];
+  while ($row = $result->fetch_assoc()) {
+    $qResults[] = $row;
   }
 
-  // If not enabled, download the file directly.
-  if (!$recaptcha) {
-    download();
-  }
+  // Only care about EventIds
+  $ids = array_column($qResults, 'eventid');
 
-  // If enabled, use it to detect human.
-  if ($recaptcha && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['recaptcha_token'])) {
-    // Build POST request:
-    $recaptcha_url = 'https://www.google.com/recaptcha/api/siteverify';
-    $recaptcha_secret = GOOGLE_RECAPTCHA_SECRET_KEY;
-    $recaptcha_response = $_POST['recaptcha_token'];
-
-    // Make and decode POST request:
-    $response = file_get_contents($recaptcha_url . '?secret=' . $recaptcha_secret . '&response=' . $recaptcha_response);
-    $responseData  = json_decode($response);
-
-    // Take action based on the score returned:
-    if ($responseData->success && $responseData->score >= 0.5) {
-      // Verified, start downloading
-      download();
-    }
-  }
-
-  function download() {
-    global $sphinx_conn;
-
-    $qResults = [];
-    $ids = [];
-
-    // Use current $_GET variables to build the same query used on results page, minus the LIMIT
-    $sql = buildSphinxQuery();
-    $sql .= ' LIMIT 99999 OPTION max_matches=99999';
-    $result = $sphinx_conn->query($sql);
-
-    while ($row = $result->fetch_assoc()) {
-      $qResults[] = $row;
-    }
-
-    // Only care about EventIds
-    $ids = array_column($qResults, 'eventid');
-
-    // Send IDs array to get all event info, returns JSON Doc
-    getResultsJSON($ids);
-
-    global $conn;
-    if (isset($conn) && $conn instanceof mysqli) { $conn->close(); }
-    if (isset($sphinx_conn) && $sphinx_conn instanceof mysqli) { $sphinx_conn->close(); }
-
-    die();
-  }
-
-?>
-<html>
-<head>
-<title>Download JSON</title>
-
-<script
-  src="https://www.google.com/recaptcha/api.js?render=<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>">
-</script>
-<script>
-  grecaptcha.ready(function() {
-    grecaptcha.execute("<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>", {action: 'download'}).then(function(token) {
-      // Send the token to your server
-      document.getElementById('recaptcha-token').value = token;
-    });
-  });
-</script>
-<style>
-  .backdrop {
-    position: fixed; /* Positions the backdrop relative to the viewport */
-    top: 0;
-    left: 0;
-    width: 100vw; /* Full viewport width */
-    height: 100vh; /* Full viewport height */
-    background-color: rgba(41, 33, 18); /* Semi-transparent black backdrop */
-    display: flex; /* Enables flexbox for centering */
-    justify-content: center; /* Horizontally centers content */
-    align-items: center; /* Vertically centers content */
-    z-index: 999; /* Ensures the backdrop is on top of other content */
-  }
-
-  .centered-button {
-    /* Basic button styling */
-    padding: 15px 30px;
-    font-size: 1.2em;
-    background-color: #6e2424;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-}
-</style>
-</head>
-<body class="backdrop">
-<form method="POST" id="recaptcha-form">
-  <input type="hidden" name="recaptcha_token" id="recaptcha-token"/>
-  <button type="submit" class="centered-button">I'm human.</button>
-</form>
-</body>
-</html>
+  // Send IDs array to get all event info, returns JSON Doc
+  getResultsJSON($ids);

--- a/get_all_sphinx_xml.php
+++ b/get_all_sphinx_xml.php
@@ -1,113 +1,23 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
-  // Check Google reCAPTCHA settings.
-  $recaptcha = FALSE;
-  if (defined("GOOGLE_RECAPTCHA_SITE_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SITE_KEY) &&
-      defined("GOOGLE_RECAPTCHA_SECRET_KEY") &&
-      !empty(GOOGLE_RECAPTCHA_SECRET_KEY)
-     ) {
-      $recaptcha = TRUE;
+  global $sphinx_conn;
+
+  // Use current $_GET variables to build the same query used on results page, minus the LIMIT
+  $sql  = buildSphinxQuery();
+  $sql .= ' LIMIT 99999 OPTION max_matches=99999';
+  $result = $sphinx_conn->query($sql);
+
+  $qResults = [];
+  while ($row = $result->fetch_assoc()) {
+    $qResults[] = $row;
   }
 
-  // If not enabled, download the file directly.
-  if (!$recaptcha) {
-    download();
-  }
+  // Only care about EventIds
+  $ids = array_column($qResults, 'eventid');
 
-  // If enabled, use it to detect human.
-  if ($recaptcha && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['recaptcha_token'])) {
-    // Build POST request:
-    $recaptcha_url = 'https://www.google.com/recaptcha/api/siteverify';
-    $recaptcha_secret = GOOGLE_RECAPTCHA_SECRET_KEY;
-    $recaptcha_response = $_POST['recaptcha_token'];
-
-    // Make and decode POST request:
-    $response = file_get_contents($recaptcha_url . '?secret=' . $recaptcha_secret . '&response=' . $recaptcha_response);
-    $responseData  = json_decode($response);
-
-    // Take action based on the score returned:
-    if ($responseData->success && $responseData->score >= 0.5) {
-      // Verified, start downloading
-      download();
-    }
-  }
-
-  function download() {
-    global $sphinx_conn;
-
-    $qResults = [];
-    $ids = [];
-
-    // Use current $_GET variables to build the same query used on results page, minus the LIMIT
-    $sql = buildSphinxQuery();
-    $sql .= ' LIMIT 99999 OPTION max_matches=99999';
-    $result = $sphinx_conn->query($sql);
-
-    while ($row = $result->fetch_assoc()) {
-      $qResults[] = $row;
-    }
-
-    // Only care about EventIds
-    $ids = array_column($qResults, 'eventid');
-
-    // Send IDs array to get all event info, returns XML Doc
-    getResultsXML($ids);
-
-    global $conn;
-    if (isset($conn) && $conn instanceof mysqli) { $conn->close(); }
-    if (isset($sphinx_conn) && $sphinx_conn instanceof mysqli) { $sphinx_conn->close(); }
-
-    die();
-  }
-
-?>
-<html>
-<head>
-<title>Download XML</title>
-
-<script
-  src="https://www.google.com/recaptcha/api.js?render=<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>">
-</script>
-<script>
-  grecaptcha.ready(function() {
-    grecaptcha.execute("<?php echo GOOGLE_RECAPTCHA_SITE_KEY; ?>", {action: 'download'}).then(function(token) {
-      // Send the token to your server
-      document.getElementById('recaptcha-token').value = token;
-    });
-  });
-</script>
-<style>
-  .backdrop {
-    position: fixed; /* Positions the backdrop relative to the viewport */
-    top: 0;
-    left: 0;
-    width: 100vw; /* Full viewport width */
-    height: 100vh; /* Full viewport height */
-    background-color: rgba(41, 33, 18); /* Semi-transparent black backdrop */
-    display: flex; /* Enables flexbox for centering */
-    justify-content: center; /* Horizontally centers content */
-    align-items: center; /* Vertically centers content */
-    z-index: 999; /* Ensures the backdrop is on top of other content */
-  }
-
-  .centered-button {
-    /* Basic button styling */
-    padding: 15px 30px;
-    font-size: 1.2em;
-    background-color: #6e2424;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-}
-</style>
-</head>
-<body class="backdrop">
-<form method="POST" id="recaptcha-form">
-  <input type="hidden" name="recaptcha_token" id="recaptcha-token"/>
-  <button type="submit" class="centered-button">I'm human.</button>
-</form>
-</body>
-</html>
+  // Send IDs array to get all event info, returns XML Doc
+  getResultsXML($ids);

--- a/get_csv.php
+++ b/get_csv.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
   $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);

--- a/get_json.php
+++ b/get_json.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
   $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);

--- a/get_tcp.php
+++ b/get_tcp.php
@@ -1,4 +1,7 @@
 <?php
+// Turnstile gate: challenge unverified visitors before opening any DB connection.
+require_once 'includes/turnstile_gate.php';
+
 include_once('includes/functions.php');
     # Strip special characters
     $fn = filter_input(INPUT_GET, 'fn', FILTER_SANITIZE_SPECIAL_CHARS);

--- a/get_xml.php
+++ b/get_xml.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 
   $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -30,39 +30,37 @@
     return;
   }
 
-  // A challenge was just solved: verify the token server-side, then redirect back
-  // to the originally requested URL (GET) so the shareable results URL stays clean.
-  if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cf-turnstile-response'])) {
-    $context = stream_context_create([
-      'http' => [
-        'method'  => 'POST',
-        'header'  => 'Content-Type: application/x-www-form-urlencoded',
-        'content' => http_build_query([
-          'secret'   => TURNSTILE_SECRET_KEY,
-          'response' => $_POST['cf-turnstile-response'],
-          'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        ]),
-        'timeout' => 10,
-      ],
-    ]);
-    $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
-    $data   = json_decode($verify);
+  // A POST means the visitor (or the widget's auto-submit callback) is attempting
+  // to verify. Any non-success outcome — siteverify error, wrong secret, expired
+  // or duplicate token, or no token at all (widget failed to produce one, e.g.
+  // bad site key) — drops into the retry UI. We never silently re-render the
+  // auto-submitting challenge: that would loop.
+  $verify_failed = false;
+  if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!empty($_POST['cf-turnstile-response'])) {
+      $context = stream_context_create([
+        'http' => [
+          'method'  => 'POST',
+          'header'  => 'Content-Type: application/x-www-form-urlencoded',
+          'content' => http_build_query([
+            'secret'   => TURNSTILE_SECRET_KEY,
+            'response' => $_POST['cf-turnstile-response'],
+            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+          ]),
+          'timeout' => 10,
+        ],
+      ]);
+      $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
+      $data   = json_decode($verify);
 
-    if ($data && !empty($data->success)) {
-      $_SESSION['ls_turnstile_verified'] = true;
-      // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
-      header('Location: ' . $_SERVER['REQUEST_URI']);
-      exit;
+      if ($data && !empty($data->success)) {
+        $_SESSION['ls_turnstile_verified'] = true;
+        // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
+        header('Location: ' . $_SERVER['REQUEST_URI']);
+        exit;
+      }
     }
-
-    // A token was POSTed but siteverify did not return success (Cloudflare API
-    // outage, network failure, wrong secret, expired/duplicate token, etc.).
-    // DO NOT silently re-render the auto-submitting challenge: the client widget
-    // would auto-solve again and re-POST in a tight loop, hammering siteverify
-    // until the underlying issue clears. Render a manual-retry page instead.
     $verify_failed = true;
-  } else {
-    $verify_failed = false;
   }
 
   // Not verified: render the challenge (or the manual-retry error page) and stop
@@ -114,30 +112,35 @@
 </head>
 <body>
   <div class="turnstile-card">
-    <?php if ($verify_failed): ?>
+    <p id="msg-fresh"<?php if ($verify_failed) echo ' style="display:none"'; ?>>Please verify you are human to continue to the search results.</p>
+    <div id="msg-failed"<?php if (!$verify_failed) echo ' style="display:none"'; ?>>
       <p><strong>Verification failed.</strong></p>
       <p>Please solve the challenge below, then click <em>Try again</em>.</p>
-    <?php else: ?>
-      <p>Please verify you are human to continue to the search results.</p>
-    <?php endif; ?>
+    </div>
     <form method="POST" action="<?php echo $action; ?>" id="turnstile-form">
       <div class="cf-turnstile"
            data-sitekey="<?php echo $site_key; ?>"
            data-retry="never"
+           data-error-callback="onTurnstileError"
            <?php if (!$verify_failed): ?>data-callback="onTurnstileSuccess"<?php endif; ?>></div>
-      <?php if ($verify_failed): ?>
-        <p><button type="submit" class="retry-btn">Try again</button></p>
-      <?php endif; ?>
+      <p id="retry-button-wrap"<?php if (!$verify_failed) echo ' style="display:none"'; ?>>
+        <button type="submit" class="retry-btn">Try again</button>
+      </p>
       <noscript><p>JavaScript is required to continue.</p></noscript>
     </form>
   </div>
-  <?php if (!$verify_failed): ?>
   <script>
+    function onTurnstileError(code) {
+      document.getElementById('msg-fresh').style.display = 'none';
+      document.getElementById('msg-failed').style.display = 'block';
+      document.getElementById('retry-button-wrap').style.display = 'block';
+    }
+    <?php if (!$verify_failed): ?>
     function onTurnstileSuccess(token) {
       document.getElementById('turnstile-form').submit();
     }
+    <?php endif; ?>
   </script>
-  <?php endif; ?>
 </body>
 </html>
 <?php

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -120,7 +120,6 @@
     <form method="POST" action="<?php echo $action; ?>" id="turnstile-form">
       <div class="cf-turnstile"
            data-sitekey="<?php echo $site_key; ?>"
-           data-retry="never"
            data-error-callback="onTurnstileError"
            <?php if (!$verify_failed): ?>data-callback="onTurnstileSuccess"<?php endif; ?>></div>
       <p id="retry-button-wrap"<?php if (!$verify_failed) echo ' style="display:none"'; ?>>

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -30,37 +30,39 @@
     return;
   }
 
-  // A POST means the visitor (or the widget's auto-submit callback) is attempting
-  // to verify. Any non-success outcome — siteverify error, wrong secret, expired
-  // or duplicate token, or no token at all (widget failed to produce one, e.g.
-  // bad site key) — drops into the retry UI. We never silently re-render the
-  // auto-submitting challenge: that would loop.
-  $verify_failed = false;
-  if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!empty($_POST['cf-turnstile-response'])) {
-      $context = stream_context_create([
-        'http' => [
-          'method'  => 'POST',
-          'header'  => 'Content-Type: application/x-www-form-urlencoded',
-          'content' => http_build_query([
-            'secret'   => TURNSTILE_SECRET_KEY,
-            'response' => $_POST['cf-turnstile-response'],
-            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
-          ]),
-          'timeout' => 10,
-        ],
-      ]);
-      $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
-      $data   = json_decode($verify);
+  // A challenge was just solved: verify the token server-side, then redirect back
+  // to the originally requested URL (GET) so the shareable results URL stays clean.
+  if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cf-turnstile-response'])) {
+    $context = stream_context_create([
+      'http' => [
+        'method'  => 'POST',
+        'header'  => 'Content-Type: application/x-www-form-urlencoded',
+        'content' => http_build_query([
+          'secret'   => TURNSTILE_SECRET_KEY,
+          'response' => $_POST['cf-turnstile-response'],
+          'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+        ]),
+        'timeout' => 10,
+      ],
+    ]);
+    $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
+    $data   = json_decode($verify);
 
-      if ($data && !empty($data->success)) {
-        $_SESSION['ls_turnstile_verified'] = true;
-        // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
-        header('Location: ' . $_SERVER['REQUEST_URI']);
-        exit;
-      }
+    if ($data && !empty($data->success)) {
+      $_SESSION['ls_turnstile_verified'] = true;
+      // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
+      header('Location: ' . $_SERVER['REQUEST_URI']);
+      exit;
     }
+
+    // A token was POSTed but siteverify did not return success (Cloudflare API
+    // outage, network failure, wrong secret, expired/duplicate token, etc.).
+    // DO NOT silently re-render the auto-submitting challenge: the client widget
+    // would auto-solve again and re-POST in a tight loop, hammering siteverify
+    // until the underlying issue clears. Render a manual-retry page instead.
     $verify_failed = true;
+  } else {
+    $verify_failed = false;
   }
 
   // Not verified: render the challenge (or the manual-retry error page) and stop
@@ -120,6 +122,7 @@
     <form method="POST" action="<?php echo $action; ?>" id="turnstile-form">
       <div class="cf-turnstile"
            data-sitekey="<?php echo $site_key; ?>"
+           data-retry="never"
            data-error-callback="onTurnstileError"
            <?php if (!$verify_failed): ?>data-callback="onTurnstileSuccess"<?php endif; ?>></div>
       <p id="retry-button-wrap"<?php if (!$verify_failed) echo ' style="display:none"'; ?>>
@@ -134,6 +137,19 @@
       document.getElementById('msg-failed').style.display = 'block';
       document.getElementById('retry-button-wrap').style.display = 'block';
     }
+    // Cloudflare Turnstile throws some errors (e.g. 400020) as uncaught
+    // exceptions rather than invoking data-error-callback. Catch them at the
+    // window level and route them into the same UI swap so the visitor still
+    // sees the Try Again button on any error, not just callback-routed ones.
+    window.addEventListener('error', function (event) {
+      var isTurnstileError =
+        (event.error && event.error.name === 'TurnstileError') ||
+        (event.message && /Cloudflare Turnstile/i.test(event.message));
+      if (isTurnstileError) {
+        onTurnstileError((event.error && event.error.message) || event.message);
+        event.preventDefault();
+      }
+    });
     <?php if (!$verify_failed): ?>
     function onTurnstileSuccess(token) {
       document.getElementById('turnstile-form').submit();

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -1,0 +1,109 @@
+<?php
+  /**
+   * Cloudflare Turnstile session gate.
+   *
+   * Include this at the very top of an entry point, BEFORE includes/functions.php
+   * (which opens the database connections). An unverified visitor is shown a
+   * one-time Turnstile challenge and the script exits here, so no DB connection
+   * is opened for bot/scraper traffic. Once a visitor solves the challenge, a
+   * session flag lets every subsequent request through untouched.
+   */
+
+  require_once __DIR__ . '/turnstile_config.php';
+
+  // Not configured (empty keys): do nothing so the site works without Turnstile.
+  if (TURNSTILE_SITE_KEY === '' || TURNSTILE_SECRET_KEY === '') {
+    return;
+  }
+
+  if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+  }
+
+  // Already verified this session — let the request proceed to open the DB and run.
+  if (!empty($_SESSION['ls_turnstile_verified'])) {
+    return;
+  }
+
+  // A challenge was just solved: verify the token server-side, then redirect back
+  // to the originally requested URL (GET) so the shareable results URL stays clean.
+  if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cf-turnstile-response'])) {
+    $context = stream_context_create([
+      'http' => [
+        'method'  => 'POST',
+        'header'  => 'Content-Type: application/x-www-form-urlencoded',
+        'content' => http_build_query([
+          'secret'   => TURNSTILE_SECRET_KEY,
+          'response' => $_POST['cf-turnstile-response'],
+          'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+        ]),
+        'timeout' => 10,
+      ],
+    ]);
+    $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
+    $data   = json_decode($verify);
+
+    if ($data && !empty($data->success)) {
+      $_SESSION['ls_turnstile_verified'] = true;
+      // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
+      header('Location: ' . $_SERVER['REQUEST_URI']);
+      exit;
+    }
+  }
+
+  // Not verified: render the challenge and stop BEFORE any DB connection is opened.
+  $action   = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
+  $site_key = htmlspecialchars(TURNSTILE_SITE_KEY, ENT_QUOTES, 'UTF-8');
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Verifying your browser&hellip;</title>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: rgb(41, 33, 18);
+      color: #fff;
+      font-family: sans-serif;
+    }
+    .turnstile-card {
+      text-align: center;
+      padding: 2rem;
+    }
+    .turnstile-card p {
+      margin-bottom: 1.5rem;
+      font-size: 1.1rem;
+    }
+    .cf-turnstile {
+      display: inline-block;
+    }
+  </style>
+</head>
+<body>
+  <div class="turnstile-card">
+    <p>Please verify you are human to continue to the search results.</p>
+    <form method="POST" action="<?php echo $action; ?>" id="turnstile-form">
+      <div class="cf-turnstile"
+           data-sitekey="<?php echo $site_key; ?>"
+           data-callback="onTurnstileSuccess"></div>
+      <noscript><p>JavaScript is required to continue.</p></noscript>
+    </form>
+  </div>
+  <script>
+    function onTurnstileSuccess(token) {
+      document.getElementById('turnstile-form').submit();
+    }
+  </script>
+</body>
+</html>
+<?php
+  exit;
+?>

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -9,10 +9,15 @@
    * session flag lets every subsequent request through untouched.
    */
 
-  require_once __DIR__ . '/turnstile_config.php';
+  // Load the config if present. If the file is missing, treat it the same as
+  // empty keys: the gate does nothing and the site keeps working.
+  $turnstile_config = __DIR__ . '/turnstile_config.php';
+  if (file_exists($turnstile_config)) {
+    require_once $turnstile_config;
+  }
 
-  // Not configured (empty keys): do nothing so the site works without Turnstile.
-  if (TURNSTILE_SITE_KEY === '' || TURNSTILE_SECRET_KEY === '') {
+  if (!defined('TURNSTILE_SITE_KEY') || !defined('TURNSTILE_SECRET_KEY')
+      || TURNSTILE_SITE_KEY === '' || TURNSTILE_SECRET_KEY === '') {
     return;
   }
 

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -54,9 +54,19 @@
       header('Location: ' . $_SERVER['REQUEST_URI']);
       exit;
     }
+
+    // A token was POSTed but siteverify did not return success (Cloudflare API
+    // outage, network failure, wrong secret, expired/duplicate token, etc.).
+    // DO NOT silently re-render the auto-submitting challenge: the client widget
+    // would auto-solve again and re-POST in a tight loop, hammering siteverify
+    // until the underlying issue clears. Render a manual-retry page instead.
+    $verify_failed = true;
+  } else {
+    $verify_failed = false;
   }
 
-  // Not verified: render the challenge and stop BEFORE any DB connection is opened.
+  // Not verified: render the challenge (or the manual-retry error page) and stop
+  // BEFORE any DB connection is opened.
   $action   = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
   $site_key = htmlspecialchars(TURNSTILE_SITE_KEY, ENT_QUOTES, 'UTF-8');
 ?>
@@ -90,23 +100,44 @@
     .cf-turnstile {
       display: inline-block;
     }
+    .retry-btn {
+      padding: 0.6rem 1.5rem;
+      margin-top: 1rem;
+      font-size: 1rem;
+      background-color: #6e2424;
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
   <div class="turnstile-card">
-    <p>Please verify you are human to continue to the search results.</p>
+    <?php if ($verify_failed): ?>
+      <p><strong>Verification failed.</strong></p>
+      <p>Please solve the challenge below, then click <em>Try again</em>.</p>
+    <?php else: ?>
+      <p>Please verify you are human to continue to the search results.</p>
+    <?php endif; ?>
     <form method="POST" action="<?php echo $action; ?>" id="turnstile-form">
       <div class="cf-turnstile"
            data-sitekey="<?php echo $site_key; ?>"
-           data-callback="onTurnstileSuccess"></div>
+           data-retry="never"
+           <?php if (!$verify_failed): ?>data-callback="onTurnstileSuccess"<?php endif; ?>></div>
+      <?php if ($verify_failed): ?>
+        <p><button type="submit" class="retry-btn">Try again</button></p>
+      <?php endif; ?>
       <noscript><p>JavaScript is required to continue.</p></noscript>
     </form>
   </div>
+  <?php if (!$verify_failed): ?>
   <script>
     function onTurnstileSuccess(token) {
       document.getElementById('turnstile-form').submit();
     }
   </script>
+  <?php endif; ?>
 </body>
 </html>
 <?php

--- a/includes/turnstile_gate.php
+++ b/includes/turnstile_gate.php
@@ -30,45 +30,87 @@
     return;
   }
 
-  // A challenge was just solved: verify the token server-side, then redirect back
-  // to the originally requested URL (GET) so the shareable results URL stays clean.
-  if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['cf-turnstile-response'])) {
-    $context = stream_context_create([
-      'http' => [
-        'method'  => 'POST',
-        'header'  => 'Content-Type: application/x-www-form-urlencoded',
-        'content' => http_build_query([
-          'secret'   => TURNSTILE_SECRET_KEY,
-          'response' => $_POST['cf-turnstile-response'],
-          'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        ]),
-        'timeout' => 10,
-      ],
-    ]);
-    $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
-    $data   = json_decode($verify);
+  // Hard cap: too many failed verification attempts in this session locks the
+  // visitor out with a 403 until the session expires (or they clear cookies).
+  // A cheap server-side rate limit on top of the gate, to stop a session that's
+  // malfunctioning or actively probing from running unbounded siteverify calls.
+  $turnstile_max_failed_attempts = 5;
+  $blocked = !empty($_SESSION['turnstile_failed_attempts'])
+             && $_SESSION['turnstile_failed_attempts'] >= $turnstile_max_failed_attempts;
 
-    if ($data && !empty($data->success)) {
-      $_SESSION['ls_turnstile_verified'] = true;
-      // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
-      header('Location: ' . $_SERVER['REQUEST_URI']);
-      exit;
+  // A POST is a verification attempt. Any non-success outcome (siteverify error,
+  // wrong secret, expired/duplicate/missing token, etc.) counts as a failed
+  // attempt and feeds the counter above.
+  $verify_failed = false;
+  if (!$blocked && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!empty($_POST['cf-turnstile-response'])) {
+      $context = stream_context_create([
+        'http' => [
+          'method'  => 'POST',
+          'header'  => 'Content-Type: application/x-www-form-urlencoded',
+          'content' => http_build_query([
+            'secret'   => TURNSTILE_SECRET_KEY,
+            'response' => $_POST['cf-turnstile-response'],
+            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+          ]),
+          'timeout' => 10,
+        ],
+      ]);
+      $verify = @file_get_contents('https://challenges.cloudflare.com/turnstile/v0/siteverify', false, $context);
+      $data   = json_decode($verify);
+
+      if ($data && !empty($data->success)) {
+        $_SESSION['ls_turnstile_verified'] = true;
+        unset($_SESSION['turnstile_failed_attempts']);
+        // REQUEST_URI is a same-origin path (header() rejects CRLF), so this is not an open redirect.
+        header('Location: ' . $_SERVER['REQUEST_URI']);
+        exit;
+      }
     }
 
-    // A token was POSTed but siteverify did not return success (Cloudflare API
-    // outage, network failure, wrong secret, expired/duplicate token, etc.).
-    // DO NOT silently re-render the auto-submitting challenge: the client widget
-    // would auto-solve again and re-POST in a tight loop, hammering siteverify
-    // until the underlying issue clears. Render a manual-retry page instead.
-    $verify_failed = true;
-  } else {
-    $verify_failed = false;
+    $_SESSION['turnstile_failed_attempts'] = ($_SESSION['turnstile_failed_attempts'] ?? 0) + 1;
+    if ($_SESSION['turnstile_failed_attempts'] >= $turnstile_max_failed_attempts) {
+      $blocked = true;
+    } else {
+      $verify_failed = true;
+    }
   }
 
-  // Not verified: render the challenge (or the manual-retry error page) and stop
-  // BEFORE any DB connection is opened.
+  // Render the appropriate page (403 lockout, retry, or fresh challenge) and
+  // stop BEFORE any DB connection is opened.
   $action   = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
   $site_key = htmlspecialchars(TURNSTILE_SITE_KEY, ENT_QUOTES, 'UTF-8');
+
+  if ($blocked) {
+    http_response_code(403);
+    ?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>403 Forbidden</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: flex; justify-content: center;
+           align-items: center; background-color: rgb(41, 33, 18); color: #fff;
+           font-family: sans-serif; }
+    .turnstile-card { text-align: center; padding: 2rem; max-width: 30rem; }
+    .turnstile-card h1 { font-size: 2.5rem; margin: 0 0 1rem; }
+    .turnstile-card p { font-size: 1.1rem; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <div class="turnstile-card">
+    <h1>403 Forbidden</h1>
+    <p>Too many failed verification attempts.</p>
+    <p>Please close your browser and try again later.</p>
+  </div>
+</body>
+</html>
+    <?php
+    exit;
+  }
 ?>
 <!doctype html>
 <html lang="en">

--- a/search.php
+++ b/search.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   include_once('includes/functions.php');
 ?>
 <!doctype html>

--- a/sphinx-results.php
+++ b/sphinx-results.php
@@ -1,4 +1,7 @@
 <?php
+  // Turnstile gate: challenge unverified visitors before opening any DB connection.
+  require_once 'includes/turnstile_gate.php';
+
   $start = microtime(True);
 
   include_once('includes/functions.php');


### PR DESCRIPTION
Added Cloudflare Turnstile support to replace the Google reCAPTCH for the entire site. If the config file or keys are missing, it will not break the site.

Also updated the README.md file to provide a guidance for the implementation.